### PR TITLE
Removing Pipfile and Pipfile.lock references

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -42,8 +42,6 @@ RUN curl -o /tmp/chromedriver_linux64.zip -L https://chromedriver.storage.google
     unzip /tmp/chromedriver_linux64.zip &&\
     cp chromedriver /usr/local/bin/chromedriver
 
-COPY Pipfile Pipfile.lock $HOME/peak/
-
 RUN pip3 install micropipenv &&\
     ln -s `which pip3` /usr/bin/pip &&\
     cd $HOME/peak &&\


### PR DESCRIPTION
We took Pipfile and Pipfile.lock files out because we didn't need them for modelmesh tests. Taking references to these files out from the Dockerfile, as the DockerBuild is failing in CI: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/32617/rehearse-32617-pull-ci-opendatahub-io-modelmesh-serving-main-modelmesh-serving-e2e/1574792991636197376