### PR TITLE
Removing micropipenv install

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -42,11 +42,6 @@ RUN curl -o /tmp/chromedriver_linux64.zip -L https://chromedriver.storage.google
     unzip /tmp/chromedriver_linux64.zip &&\
     cp chromedriver /usr/local/bin/chromedriver
 
-RUN pip3 install micropipenv &&\
-    ln -s `which pip3` /usr/bin/pip &&\
-    cd $HOME/peak &&\
-    micropipenv install
-
 COPY setup/operatorsetup scripts/install.sh scripts/installandtest.sh $HOME/peak/
 COPY resources $HOME/peak/operator-tests/modelmesh/resources
 COPY util $HOME/peak/operator-tests/modelmesh


### PR DESCRIPTION
Removing micropipenv install as we don't need it, and it's causing the DockerBuild to fail in CI: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/32617/rehearse-32617-pull-ci-opendatahub-io-modelmesh-serving-main-modelmesh-serving-e2e/1574820789461454848/build-log.txt

```
Failed to find Pipfile.lock or poetry.lock or requirements.txt in the current directory or any of its parent: '/root/peak'
error: build error: error building at STEP "RUN pip3 install micropipenv &&    ln -s `which pip3` /usr/bin/pip &&    cd $HOME/peak &&    micropipenv install": error while running runtime: exit status 3
```
