### PR TITLE
Allow users to manually specify creation of routes

### DIFF
--- a/odh-model-controller/config/rbac/role.yaml
+++ b/odh-model-controller/config/rbac/role.yaml
@@ -99,6 +99,7 @@ rules:
   - routes
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/quickstart/triton.yaml
+++ b/quickstart/triton.yaml
@@ -4,6 +4,7 @@ metadata:
   name: example-onnx-mnist
   annotations:
     serving.kserve.io/deploymentMode: ModelMesh
+    create-route: "True"
 spec:
   predictor:
     model:


### PR DESCRIPTION
Any inference services created with `create-route: "True"` as an annotation will have routes created for them.
If this annotation is removed, the route will be deleted.
If this annotation never existed, the route will not be created at all.

Image to be used: quay.io/anishasthana/odh-model-controller-test:v3