### PR TITLE
Fix: Fix sed for kfdef URI / CI test failure

### DIFF
--- a/tests/scripts/install.sh
+++ b/tests/scripts/install.sh
@@ -45,7 +45,7 @@ if [ -z "$PULL_NUMBER" ]; then
 else
   if [ $REPO_NAME == "modelmesh-serving" ]; then
     echo "Setting manifests in kfctl_openshift to use pull number: $PULL_NUMBER"
-    sed -i "s#uri: https://api.github.com/${REPO_OWNER}/${REPO_NAME}/tarball/main#uri: https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/tarball/pull/${PULL_NUMBER}/head#" ./kfctl_openshift.yaml
+    sed -i "s#uri: https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/tarball/main#uri: https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/tarball/pull/${PULL_NUMBER}/head#" ./kfctl_openshift.yaml
   fi
 fi
 


### PR DESCRIPTION
CI tests failing due to incorrect URI specified in the sed: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/opendatahub-io_modelmesh-serving/25/pull-ci-opendatahub-io-modelmesh-serving-main-modelmesh-serving-e2e/1587150969056006144
