### PR TITLE
oauth-proxy: raise CPU request and limit.

### DIFF
--- a/config/internal/base/deployment.yaml.tmpl
+++ b/config/internal/base/deployment.yaml.tmpl
@@ -162,10 +162,10 @@ spec:
             failureThreshold: 3
           resources:
             limits:
-              cpu: 100m
+              cpu: 2
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 500m
               memory: 256Mi
           volumeMounts:
             - mountPath: /etc/tls/private


### PR DESCRIPTION
With a CPU limit of 100m, oauth-proxy seems unable to cope with the load associated with its own liveness probes, leading to the model mesh pods being restarted every so often once a certain number of routes (inference services) are created.

Raise the CPU limit from 100m to 2.
Raise the CPU request from 100m to 0.5.

Related-to: https://github.com/opendatahub-io/modelmesh-serving/issues/62
Related-to: https://github.com/opendatahub-io/modelmesh-serving/issues/16
Signed-off-by: François Cami <fcami@redhat.com>

#### Motivation

Fix https://github.com/opendatahub-io/modelmesh-serving/issues/62

#### Modifications

```
diff --git a/config/internal/base/deployment.yaml.tmpl b/config/internal/base/deployment.yaml.tmpl
index c048971..7c4c18f 100644
--- a/config/internal/base/deployment.yaml.tmpl
+++ b/config/internal/base/deployment.yaml.tmpl
@@ -162,10 +162,10 @@ spec:
             failureThreshold: 3
           resources:
             limits:
-              cpu: 100m
+              cpu: 2
               memory: 256Mi
             requests:
-              cpu: 100m
+              cpu: 500m
               memory: 256Mi
           volumeMounts:
             - mountPath: /etc/tls/private
```

#### Result
