### PR TITLE
Update newTag to match the one in odh-manifests

### DIFF
--- a/manifests/opendatahub/runtimes/kustomization.yaml
+++ b/manifests/opendatahub/runtimes/kustomization.yaml
@@ -27,7 +27,7 @@ images:
 
   - name: ovms-1
     newName: openvino/model_server
-    newTag: "2022.1"
+    newTag: "2022.3"
 
 transformers:
   - ../default/metadataLabelTransformer.yaml


### PR DESCRIPTION
Effort to sync upstream manifests 
Ref: https://issues.redhat.com/browse/RHODS-6136

The updated openvino newTag will now match with the one in: https://github.com/opendatahub-io/odh-manifests/blob/master/model-mesh/runtimes/kustomization.yaml

This is the only difference between the manifests within upstream modelmesh repos

Signed-off-by: Selbi <43946617+heyselbi@users.noreply.github.com>
