### PR TITLE
Create etcd secrets inside initContainer

### DIFF
--- a/manifests/opendatahub/dependencies/quickstart.yaml
+++ b/manifests/opendatahub/dependencies/quickstart.yaml
@@ -47,6 +47,35 @@ spec:
           configMap:
             name: etcd-scripts
             defaultMode: 0554
+      initContainers: 
+        - name: etcd-secret-creator
+          image: quay.io/openshift/origin-cli
+          command: ["/bin/bash", "-c", "--"]
+          args:
+            - |
+              etcdpasswordexists=$(oc get secrets -o name | grep etcd-passwords || echo "false")
+              modelservingetcdexists=$(oc get secrets -o name | grep model-serving-etcd || echo "false")
+              
+              if [[ $etcdpasswordexists == "false" && $modelservingetcdexists == "false" ]]; then
+                echo "creating etcdpasswords and model-serving-etcd secrets"
+                ETC_ROOT_PSW=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 32 | head -n 1)
+                oc create secret generic etcd-passwords --type=string --from-literal=root=$ETC_ROOT_PSW
+                oc create secret generic model-serving-etcd --type=string --from-literal=etcd_connection="{\"endpoints\": \"http://etcd:2379\",\"root_prefix\": \"modelmesh-serving\",\"userid\": \"root\",\"password\": \"$ETC_ROOT_PSW\"}"
+                exit 0
+              elif [[ $etcdpasswordexists != "false" && $modelservingetcdexists == "false" ]]; then
+                echo "etcdpasswords exists, creating model-serving-etcd secret"
+                ETC_ROOT_PSW=$(oc get secrets/etcd-passwords --template={{.data.root}} | base64 -d)
+                oc create secret generic model-serving-etcd --type=string --from-literal=etcd_connection="{\"endpoints\": \"http://etcd:2379\",\"root_prefix\": \"modelmesh-serving\",\"userid\": \"root\",\"password\": \"$ETC_ROOT_PSW\"}"
+                exit 0
+              elif [[ $etcdpasswordexists == "false" && $modelservingetcdexists != "false" ]]; then
+                echo "model-serving-etcd exists, creating etcdpasswords secret"
+                ETC_ROOT_PSW=$(oc get secrets/model-serving-etcd --template={{.data.etcd_connection}} | base64 -d | grep -o '"password": *"[^"]*"' | grep -o '"[^"]*"$' | grep -oP '"\K[^"\047]+(?=["\047])') 
+                oc create secret generic etcd-passwords --type=string --from-literal=root=$ETC_ROOT_PSW
+                exit 0
+              else 
+                echo "secrets etcdpasswords and model-serving-etcd exist, doing nothing"
+                exit 0
+              fi
       containers:
         - command:
             - etcd
@@ -104,3 +133,40 @@ spec:
                   - /bin/sh
                   - -c
                   - /home/scripts/enable_auth.sh ${ROOT_PASSWORD}
+      serviceAccountName: etcd-serviceaccount
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-serviceaccount
+  namespace: $(monitoring-namespace) 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-role
+subjects:
+  - kind: ServiceAccount
+    name: etcd-serviceaccount

--- a/quickstart/quickstart.sh
+++ b/quickstart/quickstart.sh
@@ -30,12 +30,7 @@ MODELMESH_PROJECT=${1:-"opendatahub"}
 INFERENCE_SERVICE_PROJECT=${2:-"mesh-test"}
 
 oc new-project $MODELMESH_PROJECT
-ETC_ROOT_PSW=$(openssl rand -hex 32)
-sed -i "s/<etcd_password>/${ETC_ROOT_PSW}/g" etcd-secrets.yaml
-sed -i "s/<etcd_password>/${ETC_ROOT_PSW}/g" etcd-users.yaml
 sed -i "s/<namespace>/${MODELMESH_PROJECT}/g" ../manifests/kfdef.yaml
-oc apply -f etcd-secrets.yaml -n $MODELMESH_PROJECT
-oc apply -f etcd-users.yaml -n $MODELMESH_PROJECT
 oc apply -f ../manifests/kfdef.yaml -n $MODELMESH_PROJECT
 
 oc new-project $INFERENCE_SERVICE_PROJECT


### PR DESCRIPTION
#### Motivation
As a part of adding model-mesh to ODH, we should not have users need to apply any commands manually to deploy models using ODH. Currently the etcd secrets are created by the quickstart.sh which is not compatible with wanting a one-click deployment using a ODH kfdef. In the interest of keeping the manifests in opendatahub-io/odh-manifests and the manifests in opendatahub-io/modelmesh-serving/manifests in sync, the same change is being replicated here. 

#### Modifications
Add initContainers to the etcd deployment, along with the rbac needed to generate secrets without user intervention

#### Testing Instructions 
##### Part 1 - when etcd secrets do not already exist
- In a fresh cluster, install the OpenDataHub operator
- `cd quickstart`
- edit `manifests/kfdef.yaml` as follows `repos:name:manifests` -> `uri:  https://api.github.com/repos/VedantMahabaleshwarkar/modelmesh-serving/tarball/etcd`
- `quickstart.sh`
- Follow the quickstart readme to make a prediction against the deployed model and verify results
- Continue with steps in Part 2

##### Part 2 - if etcd secrets already exist
- in the ODH installation namespace, delete the kfdef (if it takes a long time, edit the kfdef yaml to remove finalizer and save yaml)
- `oc delete project opendatahub`
- `oc delete project mesh-test`
- Verify in Console that projects do not exist
- `oc new-project opendatahub`
- `oc project opendatahub`
- ensure you are in the `quickstart` directory
- `ETC_ROOT_PSW=$(openssl rand -hex 32)`
- `sed -i "s/<etcd_password>/${ETC_ROOT_PSW}/g" etcd-secrets.yaml`
- `sed -i "s/<etcd_password>/${ETC_ROOT_PSW}/g" etcd-users.yaml`
- `oc apply -f etcd-users.yaml`
- `oc apply -f etcd-secrets.yaml`
- `./quickstart.sh opendatahub mesh-test`
- In the console, go to project `opendatahub` -> `pods` 
- check logs for both initContainers for etcd pod
- Both initContainer logs should have `secret exists, doing nothing`

#### Result
Process for using the quickstart.sh remains the same here