### PR TITLE
Fix e2e test and add openshift-ci make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,5 +164,18 @@ check-doc-links:
 # Override targets if they are included in RUN_ARGs so it doesn't run them twice
 $(eval $(RUN_ARGS):;@:)
 
+# Openshift CI
+deploy-release-dev-mode-fvt:		
+	oc new-project ${NAMESPACE} 
+	./scripts/install.sh --namespace ${NAMESPACE} --install-config-path config --dev-mode-logging --fvt
+
+# This must use modelmesh-serving namespace because fvt has hardcoded namspace. globals.go
+# usage: NAMESPACE=modelmesh-serving make e2e-test
+e2e-test: deploy-release-dev-mode-fvt fvt
+
+# usage: NAMESPACE=modelmesh-serving make e2e-delete
+e2e-delete: delete
+	oc delete ns ${NAMESPACE}
+
 # Remove $(MAKECMDGOALS) if you don't intend make to just be a taskrunner
 .PHONY: all generate manifests check-doc-links fmt fvt controller-gen oc-login deploy-release build.develop $(MAKECMDGOALS)

--- a/config/dependencies/fvt.yaml
+++ b/config/dependencies/fvt.yaml
@@ -47,7 +47,11 @@ spec:
             - http://0.0.0.0:2379
             - --advertise-client-urls
             - http://0.0.0.0:2379
-          image: quay.io/coreos/etcd:v3.5.4
+            - '--data-dir'
+            - /tmp/etcd.data
+          # image: quay.io/coreos/etcd:v3.5.4
+          # Tag -> registry.access.redhat.com/rhel7/etcd:3.2.32-34
+          image: registry.access.redhat.com/rhel7/etcd@sha256:0d391b2f91a72d0a1f0ac7d5b0fe97698b2c5a4b3fb3e47c596521349e39c58f
           name: etcd
           ports:
             - containerPort: 2379

--- a/fvt/fvtclient.go
+++ b/fvt/fvtclient.go
@@ -56,7 +56,7 @@ import (
 	tfsapi "github.com/kserve/modelmesh-serving/fvt/generated/tensorflow_serving/apis"
 )
 
-const predictorTimeout = time.Second * 120
+const predictorTimeout = time.Second * 600
 const timeForStatusToStabilize = time.Second * 5
 
 type ModelServingConnectionType int


### PR DESCRIPTION
# Motivation
- Upstream modelmesh fvt test is not running with odh-modelmesh.
- Moreover, odh-modelmesh need to add this fvt test to openshift-ci as E2E test to check every PR validation.

# Modifications
- Add openshift-ci make targets
- Increase timeout for ISVC deployment from 120s to 600s 
- Change ETCD image from coreos to registry.access.redhat.com. 
  - Still, the image can be pulled without credential
- Change --data-dir of etcd in order to avoid permission issues.  

# Test Steps
After you login to Openshift cluster, execute the following commands:
~~~
NAMESPACE=modelmesh-serving make e2e-test
~~~

# Result
~~~
...
Ran 5 of 5 Specs in 79.927 seconds
SUCCESS! -- 5 Passed | 0 Failed | 0 Pending | 0 Skipped


Ginkgo ran 2 suites in 4m26.116938102s
Test Suite Passed
~~~
