### PR TITLE
add findutils package for openshift ci

### DIFF
--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -40,6 +40,7 @@ RUN microdnf install \
     tar \
     vim \
     git \
+    findutils \
     python38 \
     nodejs && \
     pip3 install pre-commit && \


### PR DESCRIPTION
In order to use this dockerfile.develop as a root image in the openshift ci, it needs findutils.