### PR TITLE
add modelmesh-serving-image option to accept a custom image url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,11 @@ $(eval $(RUN_ARGS):;@:)
 # Openshift CI
 deploy-release-dev-mode-fvt:		
 	oc new-project ${NAMESPACE} 
+ifdef MODELMESH_SERVING_IMAGE
+	./scripts/install.sh --namespace ${NAMESPACE} --install-config-path config --dev-mode-logging --fvt --modelmesh-serving-image ${MODELMESH_SERVING_IMAGE}
+else
 	./scripts/install.sh --namespace ${NAMESPACE} --install-config-path config --dev-mode-logging --fvt
+endif
 
 # This must use modelmesh-serving namespace because fvt has hardcoded namspace. globals.go
 # usage: NAMESPACE=modelmesh-serving make e2e-test

--- a/fvt/globals.go
+++ b/fvt/globals.go
@@ -20,7 +20,7 @@ import (
 var Log logr.Logger
 var FVTClientInstance *FVTClient
 
-var DefaultTimeout = int64(120)
+var DefaultTimeout = int64(600)
 var NameSpaceScopeMode = false
 
 var DefaultConfig = map[string]interface{}{


### PR DESCRIPTION
#### Motivation
KServe [develop guide doc](https://github.com/kserve/modelmesh-serving/blob/main/docs/developer.md) provides how to deploy a custom modelmesh serving  image.
~~~
kubectl set image deployment/modelmesh-controller manager=localhost:5000/modelmesh-controller:latest
~~~
This manual step is a little  huddle when I try to install the custom image so I add an option `modelmesh-serving-image` in install.sh to accept image url. The option will automatically update the image information.

#### Modifications
install.sh file 
- Add `--modelmesh-serving-image`

#### Result
This script will deploy ${MODELMESH_SERVING_IMAGE}. If it is not set, the default image will be deployed.
```
./scripts/install.sh --namespace ${NAMESPACE} --install-config-path config --dev-mode-logging --fvt --modelmesh-serving-image ${MODELMESH_SERVING_IMAGE}
```
