### PR TITLE
Update test-data for unit test about sa

### DIFF
--- a/controllers/testdata/test-config-defaults.yaml
+++ b/controllers/testdata/test-config-defaults.yaml
@@ -2,7 +2,7 @@ inferenceServiceName: modelmesh-serving
 inferenceServicePort: 1234
 modelMeshEndpoint: modelmesh-serving
 etcdSecretName: "secret"
-serviceAccountName: ""
+serviceAccountName: "modelmesh-serving-sa"
 podsPerRuntime: 2
 headlessService: true
 modelMeshImage:


### PR DESCRIPTION
This is about test data for unit test. 

Previously, it does not include serviceAccountName because it was hard-coded. However, it is not dynamic and it can be overrided by #74 