### PR TITLE
update test config yaml to use the right servingaccount

### DIFF
--- a/config/internal/base/deployment.yaml.tmpl
+++ b/config/internal/base/deployment.yaml.tmpl
@@ -44,7 +44,7 @@ spec:
         app.kubernetes.io/name: modelmesh-controller
         name: {{.ServiceName}}-{{.Name}}
     spec:
-      serviceAccountName: {{.ServiceAccountName}}
+      serviceAccountName: "{{.ServiceAccountName}}"
       volumes:
         - name: proxy-tls
           secret:
@@ -128,7 +128,7 @@ spec:
           args:
             - --https-address=:8443
             - --provider=openshift
-            - --openshift-service-account={{.ServiceAccountName}}
+            - --openshift-service-account="{{.ServiceAccountName}}"
             - --upstream=http://localhost:8008
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key

--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -92,7 +92,7 @@ spec:
       - args:
         - --https-address=:8443
         - --provider=openshift
-        - --openshift-service-account=
+        - --openshift-service-account="modelmesh-serving-sa"
         - --upstream=http://localhost:8008
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
@@ -403,7 +403,7 @@ spec:
       - args:
         - --https-address=:8443
         - --provider=openshift
-        - --openshift-service-account=modelmesh-serving-sa
+        - --openshift-service-account="modelmesh-serving-sa"
         - --upstream=http://localhost:8008
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
@@ -684,7 +684,7 @@ spec:
       - args:
         - --https-address=:8443
         - --provider=openshift
-        - --openshift-service-account=modelmesh-serving-sa
+        - --openshift-service-account="modelmesh-serving-sa"
         - --upstream=http://localhost:8008
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
@@ -1039,7 +1039,7 @@ spec:
       - args:
         - --https-address=:8443
         - --provider=openshift
-        - --openshift-service-account=modelmesh-serving-sa
+        - --openshift-service-account="modelmesh-serving-sa"
         - --upstream=http://localhost:8008
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
@@ -1343,7 +1343,7 @@ spec:
       - args:
         - --https-address=:8443
         - --provider=openshift
-        - --openshift-service-account=modelmesh-serving-sa
+        - --openshift-service-account="modelmesh-serving-sa"
         - --upstream=http://localhost:8008
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
@@ -1639,7 +1639,7 @@ spec:
       - args:
         - --https-address=:8443
         - --provider=openshift
-        - --openshift-service-account=modelmesh-serving-sa
+        - --openshift-service-account="modelmesh-serving-sa"
         - --upstream=http://localhost:8008
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
@@ -1940,7 +1940,7 @@ spec:
       - args:
         - --https-address=:8443
         - --provider=openshift
-        - --openshift-service-account=modelmesh-serving-sa
+        - --openshift-service-account="modelmesh-serving-sa"
         - --upstream=http://localhost:8008
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key
@@ -2235,7 +2235,7 @@ spec:
       - args:
         - --https-address=:8443
         - --provider=openshift
-        - --openshift-service-account=modelmesh-serving-sa
+        - --openshift-service-account="modelmesh-serving-sa"
         - --upstream=http://localhost:8008
         - --tls-cert=/etc/tls/private/tls.crt
         - --tls-key=/etc/tls/private/tls.key

--- a/controllers/testdata/test-config-payload-processor-error.yaml
+++ b/controllers/testdata/test-config-payload-processor-error.yaml
@@ -4,7 +4,7 @@ payloadProcessors:
 inferenceServicePort: 1234
 modelMeshEndpoint: modelmesh-serving
 etcdSecretName: "secret"
-serviceAccountName: ""
+serviceAccountName: "modelmesh-serving-sa"
 podsPerRuntime: 2
 headlessService: true
 modelMeshImage:

--- a/controllers/testdata/test-config-payload-processor.yaml
+++ b/controllers/testdata/test-config-payload-processor.yaml
@@ -4,7 +4,7 @@ payloadProcessors:
 inferenceServicePort: 1234
 modelMeshEndpoint: modelmesh-serving
 etcdSecretName: "secret"
-serviceAccountName: ""
+serviceAccountName: "modelmesh-serving-sa"
 podsPerRuntime: 2
 headlessService: true
 modelMeshImage:


### PR DESCRIPTION
#### Motivation
The tmpl file does not set {{.ServiceAccountName}}. It required double-quote so I added it.
Plus I updated payload test config to use the right serviceaccount.

#### Test
~~~
make run test
~~~

#### Result
~~~
go test -coverprofile cover.out `go list ./... | grep -v fvt`
?       github.com/kserve/modelmesh-serving     [no test files]
ok      github.com/kserve/modelmesh-serving/apis/serving/v1alpha1       0.059s  coverage: 1.8% of statements
ok      github.com/kserve/modelmesh-serving/controllers 14.623s coverage: 17.2% of statements
ok      github.com/kserve/modelmesh-serving/controllers/config  0.015s  coverage: 33.0% of statements
ok      github.com/kserve/modelmesh-serving/controllers/modelmesh       0.021s  coverage: 44.0% of statements
?       github.com/kserve/modelmesh-serving/generated/mmesh     [no test files]
ok      github.com/kserve/modelmesh-serving/pkg/config  0.079s  coverage: 49.6% of statements
ok      github.com/kserve/modelmesh-serving/pkg/mmesh   0.042s  coverage: 25.0% of statements
ok      github.com/kserve/modelmesh-serving/pkg/predictor_source        12.233s coverage: 54.6% of statements
~~~
