### PR TITLE
add trustAI processor into tmpl file

### DIFF
--- a/config/internal/base/deployment.yaml.tmpl
+++ b/config/internal/base/deployment.yaml.tmpl
@@ -63,6 +63,8 @@ spec:
           env:
             - name: MM_SERVICE_NAME
               value: {{.ServiceName}}
+            - name: MM_PAYLOAD_PROCESSORS
+              value: {{.PayloadProcessors}}
             # External gRPC port of the service, should match ports.containerPort
             - name: MM_SVC_GRPC_PORT
               value: "{{.Port}}"


### PR DESCRIPTION
#### Motivation
This added MM parameter `MM_PAYLOAD_PROCESSORS` for trustAI. 

#### Test
~~~
NAMESPACE=modelmesh-serving make e2e-test
~~~

#### Result
~~~
Ran 5 of 5 Specs in 79.927 seconds
SUCCESS! -- 5 Passed | 0 Failed | 0 Pending | 0 Skipped


Ginkgo ran 2 suites in 4m26.116938102s
Test Suite Passed
~~~
