### PR TITLE
Add downloading required binaries logic 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ opendatahub/scripts/manifests/params.env
 opendatahub/scripts/manifests/fvt/
 opendatahub/scripts/manifests/runtimes/
 kfctl*
+bin

--- a/opendatahub/scripts/deploy_fvt.sh
+++ b/opendatahub/scripts/deploy_fvt.sh
@@ -67,6 +67,19 @@ while (($# > 0)); do
   shift
 done    
 
+info ".. Downloading kustomize"
+if [[ ! -d ${ROOT_DIR}/bin ]]; then
+  info ".. Creating a bin folder"
+  mkdir -p ${ROOT_DIR}/bin
+fi
+
+export KUSTOMIZE_VERSION=4.5.2 
+curl -sSLf --output /tmp/kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz
+tar -xvf /tmp/kustomize.tar.gz -C /tmp 
+mv /tmp/kustomize  ${ROOT_DIR}/bin
+chmod a+x  ${ROOT_DIR}/bin
+rm -v /tmp/kustomize.tar.gz
+
 echo "* Start to prepare FVT test environment"
 allowedImgName=false
 if [[ ${img_map} != none ]]; then

--- a/opendatahub/scripts/env.sh
+++ b/opendatahub/scripts/env.sh
@@ -3,10 +3,12 @@
 export SCRIPT_DIR=$(dirname "$(realpath "$0")")
 export MANIFESTS_DIR=$SCRIPT_DIR/manifests
 export OPENDATAHUB_DIR=$(dirname "$SCRIPT_DIR")
+export ROOT_DIR=${OPENDATAHUB_DIR}/..
 export ODH_MANIFESTS_DIR=$OPENDATAHUB_DIR/odh-manifests
 export MM_HOME_DIR=/tmp/modelmesh-e2e
 export KFDEF_FILE=${MM_HOME_DIR}/kfdef.yaml
 
+export PATH=${ROOT_DIR}/bin:$PATH
 # echo $SCRIPT_DIR
 # echo $MANIFESTS_DIR
 # echo $OPENDATAHUB_DIR


### PR DESCRIPTION
#### Motivation
Scripts for a quick start is not using dockerfile.develop container so it needs to download the required binaries.

#### Modifications
Adding downloading binaries logic.

#### Result
It downloads
- kfctl
- kustomize
- yq
into ./bin folder.

#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [V] Unit tests pass locally
- [V] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [V] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
