### PR TITLE
Fix quickstart link in /README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-[![Build and Push](https://github.com/kserve/modelmesh-serving/actions/workflows/build-and-push.yml/badge.svg)](https://github.com/kserve/modelmesh-serving/actions/workflows/build-and-push.yml)
-
 # ModelMesh Serving
 
 ModelMesh Serving is the Controller for managing ModelMesh, a general-purpose model serving management/routing layer.
 
 ## Getting Started
 
-To quickly get started with ModelMesh Serving, check out the [Quick Start Guide](./docs/quickstart.md).
+To quickly get started with ModelMesh Serving, check out the [Quick Start Guide](./opendatahub/quickstart/basic).
 
 For help, please open an issue in this repository.
 


### PR DESCRIPTION
#### Motivation

In main README, the link to the quickstart guide goes to the upstream instructions that does not work for ODH:

#### Modifications

The link is fixed to point to the right quickstart guide.

