### PR TITLE
Fix quick start link to go to the root of quick starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ModelMesh Serving is the Controller for managing ModelMesh, a general-purpose mo
 
 ## Getting Started
 
-To quickly get started with ModelMesh Serving, check out the [Quick Start Guide](./opendatahub/quickstart/basic).
+To quickly get started with ModelMesh Serving, check out the [Quick Start Guide](./opendatahub/quickstart).
 
 For help, please open an issue in this repository.
 


### PR DESCRIPTION
Follow-up of #108