### PR TITLE
[Cherry-Pick]Add Profiling feature to get debug data for modelmesh controller.

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,11 +16,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
@@ -81,6 +84,7 @@ const (
 	NamespaceScopeEnvVar              = "NAMESPACE_SCOPE"
 	TrueString                        = "true"
 	FalseString                       = "false"
+	EnablePprof                       = "ENABLE_PPROF"
 )
 
 func init() {
@@ -273,6 +277,50 @@ func main() {
 		os.Exit(1)
 	}
 
+	enablePprof := os.Getenv(EnablePprof)
+	if enablePprof != "" {
+		// Enable PPROF 
+		setupLog.Info("Started PPROF HTTP server", "host","","port","9999")
+		go func() {
+			var username string
+			var password string
+
+			etcdSecret := &corev1.Secret{}
+			if err = cl.Get(context.Background(), client.ObjectKey{Name: cp.GetConfig().GetEtcdSecretName(), Namespace: controllerNamespace}, etcdSecret); err != nil {
+				log.Fatal(err)
+			}
+
+			for key, value := range etcdSecret.Data {
+				if key == modelmesh.EtcdSecretKey {
+					var data map[string]json.RawMessage
+					err := json.Unmarshal(value, &data)
+					if err != nil {
+						log.Fatalf("Failed to parse JSON: %v", err)
+					}
+					username = strings.Trim(string(data["userid"]), `"`)
+					password = strings.Trim(string(data["password"]), `"`)
+				}
+			}
+
+			authMiddleware := func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					u, p, ok := r.BasicAuth()
+					if !ok || u != username || p != password {
+						w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+						http.Error(w, "Unauthorized", http.StatusUnauthorized)
+						return
+					}
+
+					next.ServeHTTP(w, r)
+				})
+			}
+
+			mux := http.NewServeMux()
+			mux.Handle("/debug/", authMiddleware(http.DefaultServeMux))
+			log.Fatal(http.ListenAndServe(":9999", mux))
+		}()
+	}
+	
 	// Check if the ServiceMonitor CRD exists in the cluster
 	sm := &monitoringv1.ServiceMonitor{}
 	serviceMonitorCRDExists := true


### PR DESCRIPTION
#### Motivation
Modelmesh Controller has a memory leak issue(https://issues.redhat.com/browse/RHODS-8868) so it needs to gather heapdump. In order to get detailed data, `net/http/pprof` package should be added.

This change will deploy a webserver and it provides to download data but this web server requires authentication to download debugging data.

Main branch - https://github.com/opendatahub-io/modelmesh-serving/pull/102

#### Modifications
Added pprof package.

#### Test

Add `ENABLE_PPROF` environmental variable in the odh-modelmesh-controller deployment.
~~~
oc port-forward pod/modelmesh-controller-XXXX  9999:9999
http://localhost:9999/debug/pprof/heap
~~~

#### Result
~~~
heap file will be downloaded.
~~~

#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [X] Unit tests pass locally
- [X] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [X] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
