### PR TITLE
Enhance gen-scripts for new manifests

### DIFF
--- a/opendatahub/docs/generate-manifests.md
+++ b/opendatahub/docs/generate-manifests.md
@@ -1,0 +1,129 @@
+# How to use gen scripts
+
+There are 3 gen scripts to support generating new manifests.
+- [gen_odh_model_manifests.sh](../scripts/gen_odh_model_manifests.sh)
+- [gen_odh_modelmesh_manifests.sh](../scripts/gen_odh_modelmesh_manifests.sh)
+- [gen_copy_new_manifests.sh](../scripts/gen_copy_new_manifests.h)
+
+To simplify, here's how the script works.
+First, the above scripts generates new manifests and compares it with existing manifest without touching the existing manifests. If there are any differences, [gen_copy_new_manifests.sh](../scripts/gen_copy_new_manifests.h) copies the new manifests under the odh-manifests folder,then runs the fvt test, and if there are any problems, you have to manually modify the new manifests to make them work. If you modify the new manifests, you must also update odh-manifests/model-mesh_template or model-mesh_template_stable. 
+
+## Common
+
+The temporary folder name is stored in this file (opendatahub/scripts/.temp_new_modelmesh_manifests). If this file exist, the folder name will be reused or a new file will be recreated. `gen_odh_model_manifests.sh` and `gen_odh_modelmesh_manifests.sh` have an option(-n, --create-new-dir) to delete the file to recreate.
+
+~~~
+cat opendatahub/scripts/.temp_new_modelmesh_manifests
+modelmesh-20230608061686254480
+~~~
+
+## [gen_odh_model_manifests.sh](../scripts/gen_odh_model_manifests.sh)
+
+This script clones a specific branch of the odh-model-controller repository and copies the manifests file from the config folder to the bottom of the /tmp/modelmesh-XXXX folder. Then use `opendatahub/scripts/gen_manifests/odh_model_manifests.sh` or `odh_model_manifests_stable.sh` to customize the copied manifests to run for opendatahub.
+
+**Script Usage**
+
+~~~
+$ opendatahub/scripts/gen_odh_model_manifests.sh --help
+usage: opendatahub/scripts/gen_odh_model_manifests.sh [flags]
+
+Flags:
+  -p, --stable-manifests       (optional) Use stable manifests. By default, it will use the latest manifests (default false).
+  -b, --clone-branch           (optional) Use other branch to clone. By default, it will use the main branch (default main).
+  -n, --create-new-dir         (optional) Use a new directory. By default, it uses the existing directory if it exists (default false).
+
+Generate odh-manifest for odh-modelmesh-controller
+~~~
+
+**Use Cases - main branch**
+
+Create a new temp folder name and generate a new odh-model-controller with main branch. Customize the manifests with `opendatahub/odh-manifests/model-mesh_template`
+~~~
+opendatahub/scripts/gen_odh_model_manifests.sh -n
+~~~
+
+**Use Cases - stable branch**
+
+Create a new temp folder name and generate a new odh-model-controller with custom branch. Customize the manifests with `opendatahub/odh-manifests/model-mesh_template_stable`
+~~~
+opendatahub/scripts/gen_odh_model_manifests.sh -p -b release-v0.11.0-alpha -n
+~~~
+
+**Use Cases - custom branch**
+
+Create a new temp folder name and generate a new odh-model-controller with custom branch. Customize the manifests with `opendatahub/odh-manifests/model-mesh_template`
+~~~
+opendatahub/scripts/gen_odh_model_manifests.sh -b release-v0.11.0-alpha -n
+~~~
+
+## [gen_odh_modelmesh_manifests.sh](../scripts/gen_odh_modelmesh_manifests.sh)
+
+This script clones a specific branch of the odh-modelmesh-controller repository and copies the manifests file from the config folder to the bottom of the /tmp/modelmesh-XXXX folder. Then use `opendatahub/scripts/gen_manifests/odh_modelmesh_manifests.sh` or `odh_modelmesh_manifests_stable.sh` to customize the copied manifests to run inside opendatahub.
+
+**Script Usage**
+
+~~~
+$ opendatahub/scripts/gen_odh_modelmesh_manifests.sh --help
+usage: opendatahub/scripts/gen_odh_modelmesh_manifests.sh [flags]
+
+Flags:
+  -p, --stable-manifests         (optional) Use stable manifests. By default, it will use the latest manifests (default false).
+  -b, --clone-branch             (optional) Use other branch to clone. By default, it will use the main branch (default main).
+  -n, --create-new-dir           (optional) Use a new directory. By default, it uses the existing directory if it exists (default false).
+  -c, --copy-current-config-dir  (optional) Use a current config directory to compare. By default, it uses the existing config directory instead of cloning git repository (default false).
+
+Generate odh-manifest for odh-modelmesh-controller
+~~~
+
+**Use Cases - main branch**
+
+Create a new temp folder name and generate a new odh-modelmesh-controller with main branch. Customize the manifests with `opendatahub/odh-manifests/model-mesh_template`
+~~~
+opendatahub/scripts/gen_odh_modelmesh_manifests.sh -n
+~~~
+
+**Use Cases - stable branch**
+
+Create a new temp folder name and generate a new odh-modelmesh-controller with custom branch. Customize the manifests with `opendatahub/odh-manifests/model-mesh_template_stable`
+~~~
+opendatahub/scripts/gen_odh_modelmesh_manifests.sh -p -b release-v0.11.0-alpha -n
+~~~
+
+**Use Cases - custom branch**
+
+Create a new temp folder name and generate a new odh-modelmesh-controller with custom branch. Customize the manifests with `opendatahub/odh-manifests/model-mesh_template`
+~~~
+opendatahub/scripts/gen_odh_modelmesh_manifests.sh -b release-v0.11.0-alpha -n
+~~~
+
+## [gen_copy_new_manifests.sh](../scripts/gen_copy_new_manifests.h)
+
+This script does the following:
+- Move `opendatahub/odh-manifests/model-mesh` to `opendatahub/odh-manifests/model-mesh-ori`
+- Copy `/tmp/modelmesh-XXXX` to `opendatahub/odh-manifests/model-mesh` or `opendatahub/odh-manifests/model-mesh_stable`
+  
+**Script Usage**
+
+~~~
+$ opendatahub/scripts/gen_copy_new_manifests.sh --help
+usage: opendatahub/scripts/gen_copy_new_manifests.sh [flags]
+
+Flags:
+  -p, --stable-manifests         (optional) Use stable manifests. By default, it will use the latest manifests (default false).
+
+Copy the generated new odh-manifest to opendatahub/odh-manifests/model-mesh,model-mesh_stable
+~~~
+
+**Use Cases - main branch**
+
+Move `opendatahub/odh-manifests/model-mesh` to `opendatahub/odh-manifests/model-mesh_ori` and move `/tmp/modelmesh-XXX` to `opendatahub/odh-manifests/model-mesh`.
+~~~
+opendatahub/scripts/gen_copy_new_manifests.sh
+~~~
+
+**Use Cases - stable branch**
+
+Move `opendatahub/odh-manifests/model-mesh_stable` to `opendatahub/odh-manifests/model-mesh_stable_ori` and move `/tmp/modelmesh-XXX` to `opendatahub/odh-manifests/model-mesh_stable`.
+~~~
+opendatahub/scripts/gen_copy_new_manifests.sh -p 
+~~~

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/OWNERS
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/OWNERS
@@ -1,0 +1,19 @@
+ approvers:
+  - anishasthana
+  - danielezonca
+  - heyselbi
+  - israel-hdez
+  - Jooho
+  - vaibhavjainwiz
+  - VedantMahabaleshwarkar
+  - Xaenalt
+  
+reviewers:
+  - anishasthana
+  - danielezonca
+  - heyselbi
+  - israel-hdez
+  - Jooho
+  - vaibhavjainwiz
+  - VedantMahabaleshwarkar
+  - Xaenalt

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/README.md
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/README.md
@@ -1,0 +1,79 @@
+# Model Mesh Serving
+
+Model Mesh Serving comes with 1 components:
+
+1. [modelmesh](#modelmesh)
+
+## modelmesh
+
+Contains deployment manifests for the model mesh service and odh model controller.
+
+- [odh-modelmesh-controller](https://github.com/opendatahub-io/modelmesh-serving)
+  - Forked upstream kserve/modelmesh-serving repository
+- [odh-model-controller](https://github.com/opendatahub-io/odh-model-controller)
+  - Controller to manage ingress service of Model Mesh.
+
+## Model Mesh Serving Architecture
+
+A complete architecture can be found at https://github.com/kserve/modelmesh-serving
+
+In general, Model Mesh Serving deploys a controller that works on the ServingRuntime and Predictor CRDs. There are many
+supported ServingRuntimes that support different model types. When a ServingRuntime is created/installed, you can then
+create a predictor instance to serve the model described in that predictor. Briefly, the predictor definition includes
+an S3 storage location for that model as well as the credentials to fetch it. Also included in the predictor definition
+is the model type, which is used by the controller to map to the appropriate serving runtime.
+
+The models being served can be reached via both gRPC (natively) and REST (via provided proxy).
+
+### Parameters
+
+You can set images though `parameters`.
+
+- odh-mm-rest-proxy
+- odh-modelmesh-runtime-adapter
+- odh-modelmesh
+- odh-openvino
+- odh-modelmesh-controller
+- odh-model-controller
+
+##### Examples
+
+Example ServingRuntime and Predictors can be found at: https://github.com/kserve/modelmesh-serving/blob/main/docs/quickstart.md
+
+### Overlays
+
+None
+
+### Installation process
+
+Following are the steps to install Model Mesh as a part of OpenDataHub install:
+
+1. Install the OpenDataHub operator
+2. Create a KfDef that includes the model-mesh component with the odh-model-controller overlay.
+
+```
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: opendatahub
+  namespace: opendatahub
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: model-mesh
+      name: model-mesh
+  repos:
+    - name: manifests
+      uri: https://api.github.com/repos/opendatahub-io/odh-manifests/tarball/master
+  version: master
+
+```
+
+3. You can now create a new project and create an InferenceService CR.

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/base/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/base/kustomization.yaml
@@ -1,0 +1,73 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../odh-modelmesh-controller/overlays/odh
+  - ../odh-model-controller/overlays/odh
+
+commonLabels:
+  app.kubernetes.io/part-of: model-mesh
+namespace: opendatahub
+configMapGenerator:
+  - envs:
+      - params.env
+    name: mesh-parameters
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+  - fieldref:
+      fieldPath: metadata.namespace
+    name: mesh-namespace
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: mesh-parameters
+  - fieldref:
+      fieldPath: data.monitoring-namespace
+    name: monitoring-namespace
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: mesh-parameters
+  - fieldref:
+      fieldPath: data.odh-modelmesh
+    name: odh-modelmesh
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: mesh-parameters
+  - fieldref:
+      fieldPath: data.odh-mm-rest-proxy
+    name: odh-mm-rest-proxy
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: mesh-parameters
+  - fieldref:
+      fieldPath: data.odh-modelmesh-runtime-adapter
+    name: odh-modelmesh-runtime-adapter
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: mesh-parameters
+  - fieldref:
+      fieldPath: data.odh-modelmesh-controller
+    name: odh-modelmesh-controller
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: mesh-parameters
+  - fieldref:
+      fieldPath: data.odh-model-controller
+    name: odh-model-controller
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: mesh-parameters
+  - fieldref:
+      fieldPath: data.odh-openvino
+    name: odh-openvino
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: mesh-parameters

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/base/params.env
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/base/params.env
@@ -1,0 +1,7 @@
+monitoring-namespace=opendatahub
+odh-mm-rest-proxy=quay.io/opendatahub/rest-proxy:v0.10.0
+odh-modelmesh-runtime-adapter=quay.io/opendatahub/modelmesh-runtime-adapter:v0.11.0-alpha
+odh-modelmesh=quay.io/opendatahub/modelmesh:v0.11.0-alpha
+odh-openvino=quay.io/opendatahub/openvino_model_server:2022.3-gpu
+odh-modelmesh-controller=quay.io/opendatahub/modelmesh-controller:v0.11.0-alpha
+odh-model-controller=quay.io/opendatahub/odh-model-controller:v0.11.0-alpha

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-model-controller/base/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-model-controller/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../default
+  - ../prometheus

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-model-controller/overlays/odh/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-model-controller/overlays/odh/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+patchesStrategicMerge:
+  - odh_model_controller_manager_patch.yaml
+commonLabels:
+  app.kubernetes.io/managed-by: odh-model-controller
+
+configurations:
+  - params.yaml

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-model-controller/overlays/odh/odh_model_controller_manager_patch.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-model-controller/overlays/odh/odh_model_controller_manager_patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: odh-model-controller
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - args:
+            - --leader-elect
+            - "--monitoring-namespace"
+            - "$(MONITORING_NS)"
+          image: $(odh-model-controller)
+          env:
+            - name: MONITORING_NS
+              value: $(monitoring-namespace)
+          name: manager

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-model-controller/overlays/odh/params.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-model-controller/overlays/odh/params.yaml
@@ -1,0 +1,4 @@
+varReference:
+  - path: metadata/name
+    kind: ClusterRoleBinding
+    apiGroup: authorization.openshift.io

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/base/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../default
+  - ../prometheus

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - ./scripts/
+  - ./quickstart.yaml
+  - ./rbac/
+  - ./manager
+
+commonLabels:
+  app.kubernetes.io/managed-by: modelmesh-controller
+
+configurations:
+  - params.yaml

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/manager/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/manager/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./service.yaml

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/manager/service.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/manager/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: modelmesh-controller
+  name: modelmesh-controller
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+  selector:
+    control-plane: modelmesh-controller

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/params.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/params.yaml
@@ -1,0 +1,15 @@
+varReference:
+  - path: metadata/namespace
+    kind: ServiceAccount
+    apiVersion: v1
+  - path: metadata/name
+    kind: ClusterRoleBinding
+    apiGroup: rbac.authorization.k8s.io
+  - path: subjects/namespace
+    kind: RoleBinding
+    apiGroup: rbac.authorization.k8s.io
+  - path: spec/template/spec/containers[]/image
+    kind: Deployment
+    apiVersion: apps/v1
+  - path: data
+    kind: ConfigMap

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/quickstart.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/quickstart.yaml
@@ -1,0 +1,173 @@
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd
+  labels:
+    component: model-mesh-etcd
+spec:
+  ports:
+    - name: etcd-client-port
+      port: 2379
+      protocol: TCP
+      targetPort: 2379
+  selector:
+    component: model-mesh-etcd
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: model-mesh-etcd
+  name: etcd
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: model-mesh-etcd
+  template:
+    metadata:
+      labels:
+        component: model-mesh-etcd
+    spec:
+      volumes:
+        - name: scripts
+          configMap:
+            name: etcd-scripts
+            defaultMode: 0554
+      initContainers:
+        - name: etcd-secret-creator
+          image: registry.redhat.io/openshift4/ose-cli@sha256:25fef269ac6e7491cb8340119a9b473acbeb53bc6970ad029fdaae59c3d0ca61
+          command: ["/bin/bash", "-c", "--"]
+          args:
+            - |
+              etcdpasswordexists=$(oc get secrets -o name | grep etcd-passwords || echo "false")
+              modelservingetcdexists=$(oc get secrets -o name | grep model-serving-etcd || echo "false")
+
+              if [[ $etcdpasswordexists == "false" && $modelservingetcdexists == "false" ]]; then
+                echo "creating etcdpasswords and model-serving-etcd secrets"
+                ETC_ROOT_PSW=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 32 | head -n 1)
+                oc create secret generic etcd-passwords --type=string --from-literal=root=$ETC_ROOT_PSW
+                oc create secret generic model-serving-etcd --type=string --from-literal=etcd_connection="{\"endpoints\": \"http://etcd:2379\",\"root_prefix\": \"modelmesh-serving\",\"userid\": \"root\",\"password\": \"$ETC_ROOT_PSW\"}"
+                exit 0
+              elif [[ $etcdpasswordexists != "false" && $modelservingetcdexists == "false" ]]; then
+                echo "etcdpasswords exists, creating model-serving-etcd secret"
+                ETC_ROOT_PSW=$(oc get secrets/etcd-passwords --template={{.data.root}} | base64 -d)
+                oc create secret generic model-serving-etcd --type=string --from-literal=etcd_connection="{\"endpoints\": \"http://etcd:2379\",\"root_prefix\": \"modelmesh-serving\",\"userid\": \"root\",\"password\": \"$ETC_ROOT_PSW\"}"
+                exit 0
+              elif [[ $etcdpasswordexists == "false" && $modelservingetcdexists != "false" ]]; then
+                echo "model-serving-etcd exists, creating etcdpasswords secret"
+                ETC_ROOT_PSW=$(oc get secrets/model-serving-etcd --template={{.data.etcd_connection}} | base64 -d | grep -o '"password": *"[^"]*"' | grep -o '"[^"]*"$' | grep -oP '"\K[^"\047]+(?=["\047])') 
+                oc create secret generic etcd-passwords --type=string --from-literal=root=$ETC_ROOT_PSW
+                exit 0
+              else 
+                echo "secrets etcdpasswords and model-serving-etcd exist, doing nothing"
+                exit 0
+              fi
+      containers:
+        - command:
+            - etcd
+            - --listen-client-urls
+            - http://0.0.0.0:2379
+            - --advertise-client-urls
+            - http://0.0.0.0:2379
+            - "--data-dir"
+            - /tmp/etcd.data
+          image: registry.redhat.io/rhel7/etcd@sha256:d3495b263b103681f1b09a558be43c21989bfc269eb90f84c2609042cebdc626
+          name: etcd
+          env:
+            - name: ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: etcd-passwords
+                  key: root
+          volumeMounts:
+            - mountPath: /home/scripts
+              name: scripts
+          ports:
+            - containerPort: 2379
+              name: client
+              protocol: TCP
+            - containerPort: 2380
+              name: server
+              protocol: TCP
+          resources: # ref: https://github.com/coreos/etcd-operator/blob/master/doc/user/spec_examples.md#three-member-cluster-with-resource-requirement
+            limits:
+              cpu: 300m
+              memory: 200Mi
+            requests:
+              cpu: 200m
+              memory: 100Mi
+          livenessProbe:
+            tcpSocket:
+              port: 2379
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 2379
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - /home/scripts/enable_auth.sh ${ROOT_PASSWORD}
+      serviceAccountName: etcd-serviceaccount
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-serviceaccount
+  namespace: $(mesh-namespace)
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-role
+subjects:
+  - kind: ServiceAccount
+    name: etcd-serviceaccount
+    namespace: $(mesh-namespace)

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/rbac/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/rbac/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../rbac/cluster-scope
+  - ./networkpolicy_etcd.yaml
+  - ./role_apps_metrics_access.yaml
+  - ./user_cluster_roles.yaml
+
+patchesStrategicMerge:
+  - remove_networkpolicy_rumtime_patch.yaml

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/rbac/networkpolicy_etcd.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/rbac/networkpolicy_etcd.yaml
@@ -1,0 +1,36 @@
+# Copyright 2022 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: etcd
+spec:
+  podSelector:
+    matchLabels:
+      component: model-mesh-etcd
+      app.kubernetes.io/part-of: model-mesh
+  ingress:
+    # etcd communication
+    - from:
+        - namespaceSelector:
+            # matches controller and runtime pods
+            matchLabels:
+              modelmesh-enabled: "true"
+          # mataches internal pods
+        - podSelector: {}
+      ports:
+        - port: 2379
+          protocol: TCP
+  policyTypes:
+    - Ingress

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/rbac/remove_networkpolicy_rumtime_patch.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/rbac/remove_networkpolicy_rumtime_patch.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: modelmesh-runtimes

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/rbac/role_apps_metrics_access.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/rbac/role_apps_metrics_access.yaml
@@ -1,0 +1,41 @@
+# Deploying a RoleBinding in a given Namespace
+# that gives the Prometheus SA the following role
+# will allow that Prometheus to scrape Services
+# in that RoleBinding's Namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-ns-access
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/rbac/user_cluster_roles.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/rbac/user_cluster_roles.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: model-serving-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-model-serving-admin: "true"
+rules: []
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: model-serving-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-model-serving-admin: "true"
+rules:
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - inferenceservices
+      - servingruntimes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: model-serving-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - servingruntimes
+      - servingruntimes/status
+      - servingruntimes/finalizers
+      - inferenceservices
+      - inferenceservices/status
+      - inferenceservices/finalizers
+    verbs:
+      - get
+      - list
+      - watch

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/scripts/enable_auth.sh
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/scripts/enable_auth.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e -o pipefail
+export ETCDCTL_API=3
+
+function etcd::availability() {
+    local cmd=$1 # Command whose output we require
+    local interval=$2 # How many seconds to sleep between tries
+    local iterations=$3 # How many times we attempt to run the command
+
+    ii=0
+
+    while [ $ii -le $iterations ]
+    do
+
+        token=$($cmd) && returncode=$? || returncode=$?
+        if [ $returncode -eq 0 ]; then
+            break
+        fi
+
+        ((ii=ii+1))
+        if [ $ii -eq 100 ]; then
+            echo $cmd "did not return a value"
+            exit 1
+        fi
+        sleep $interval
+    done
+    echo $token
+}
+
+cmd='etcdctl --endpoints=http://0.0.0.0:2379 endpoint health'
+
+etcd::availability "${cmd}" 6 10
+
+PASSWORD="${1:-password}"
+
+echo $PASSWORD | etcdctl --endpoints=http://0.0.0.0:2379 user add root --interactive=false
+etcdctl --endpoints=http://0.0.0.0:2379 auth enable

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/scripts/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/scripts/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: etcd-scripts
+    files:
+      - enable_auth.sh

--- a/opendatahub/scripts/gen-manifests/odh_model_manifests.sh
+++ b/opendatahub/scripts/gen-manifests/odh_model_manifests.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+echo -n ".. Delete crd folder"
+rm -rf ${ODH_MODEL_CONTROLLER_DIR}/crd
+echo -e "\r ✓"
+
+echo -n ".. Update kustomization.yaml in default folder"
+if [[ $(grep external ${ODH_MODEL_CONTROLLER_DIR}/default/kustomization.yaml|wc -l) != 0 ]]; then
+  sed '/external/d' -i ${ODH_MODEL_CONTROLLER_DIR}/default/kustomization.yaml
+  sed '/namespace/d' -i ${ODH_MODEL_CONTROLLER_DIR}/default/kustomization.yaml
+  sed '/^$/d' -i ${ODH_MODEL_CONTROLLER_DIR}/default/kustomization.yaml
+fi
+echo -e "\r ✓"
+
+echo -n ".. Update kustomization.yaml in manager folder"
+sed '/namespace.yaml/d' -i ${ODH_MODEL_CONTROLLER_DIR}/manager/kustomization.yaml
+if [[ $(grep images ${ODH_MODEL_CONTROLLER_DIR}/manager/kustomization.yaml|wc -l) != 0 ]]; then
+  sed '/images/,$d' -i ${ODH_MODEL_CONTROLLER_DIR}/manager/kustomization.yaml
+  sed '$d' -i ${ODH_MODEL_CONTROLLER_DIR}/manager/kustomization.yaml
+fi
+echo -e "\r ✓"
+
+if [[ -f ${ODH_MODEL_CONTROLLER_DIR}/manager/namespace.yaml ]]; then
+  echo -n ".. Delete namespace.yaml file"
+  rm ${ODH_MODEL_CONTROLLER_DIR}/manager/namespace.yaml
+else
+  echo -n ".. namespace.yaml file was already deleted"
+fi
+echo -e "\r ✓"
+
+echo -n ".. Add mesh-namespace into role_binding.yaml in rbac folder"
+sed 's+odh-model-controller-rolebinding$+odh-model-controller-rolebinding-$(mesh-namespace)+g' -i ${ODH_MODEL_CONTROLLER_DIR}/rbac/role_binding.yaml
+echo -e "\r ✓"

--- a/opendatahub/scripts/gen-manifests/odh_model_manifests_stable.sh
+++ b/opendatahub/scripts/gen-manifests/odh_model_manifests_stable.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+echo -n ".. Delete crd folder"
+rm -rf ${ODH_MODEL_CONTROLLER_DIR}/crd
+echo -e "\r ✓"
+
+echo -n ".. Update kustomization.yaml in default folder"
+if [[ $(grep external ${ODH_MODEL_CONTROLLER_DIR}/default/kustomization.yaml|wc -l) != 0 ]]; then
+  sed '/external/d' -i ${ODH_MODEL_CONTROLLER_DIR}/default/kustomization.yaml
+  sed '/namespace/d' -i ${ODH_MODEL_CONTROLLER_DIR}/default/kustomization.yaml
+  sed '/^$/d' -i ${ODH_MODEL_CONTROLLER_DIR}/default/kustomization.yaml
+fi
+echo -e "\r ✓"
+
+echo -n ".. Update kustomization.yaml in manager folder"
+sed '/namespace.yaml/d' -i ${ODH_MODEL_CONTROLLER_DIR}/manager/kustomization.yaml
+if [[ $(grep images ${ODH_MODEL_CONTROLLER_DIR}/manager/kustomization.yaml|wc -l) != 0 ]]; then
+  sed '/images/,$d' -i ${ODH_MODEL_CONTROLLER_DIR}/manager/kustomization.yaml
+  sed '$d' -i ${ODH_MODEL_CONTROLLER_DIR}/manager/kustomization.yaml
+fi
+echo -e "\r ✓"
+
+if [[ -f ${ODH_MODEL_CONTROLLER_DIR}/manager/namespace.yaml ]]; then
+  echo -n ".. Delete namespace.yaml file"
+  rm ${ODH_MODEL_CONTROLLER_DIR}/manager/namespace.yaml
+else
+  echo -n ".. namespace.yaml file was already deleted"
+fi
+echo -e "\r ✓"
+
+echo -n ".. Add mesh-namespace into role_binding.yaml in rbac folder"
+sed 's+odh-model-controller-rolebinding$+odh-model-controller-rolebinding-$(mesh-namespace)+g' -i ${ODH_MODEL_CONTROLLER_DIR}/rbac/role_binding.yaml
+echo -e "\r ✓"

--- a/opendatahub/scripts/gen-manifests/odh_modelmesh_manifests.sh
+++ b/opendatahub/scripts/gen-manifests/odh_modelmesh_manifests.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Update files for Opendatahub
+echo -n ".. Comment out ClusterServingRuntime"
+sed 's+- bases/serving.kserve.io_clusterservingruntimes.yaml+# - bases/serving.kserve.io_clusterservingruntimes.yaml+g' -i ${MODELMESH_CONTROLLER_DIR}/crd/kustomization.yaml
+echo -e "\r ✓"
+
+echo -n ".. Remove builtInServerTypes"
+sed '/builtInServerTypes/,$d' -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
+echo -e "\r ✓"
+
+echo -n ".. Add parameter variable into modelmesh-controller-rolebinding"
+sed 's+modelmesh-controller-rolebinding$+modelmesh-controller-rolebinding-$(mesh-namespace)+g' -i ${MODELMESH_CONTROLLER_DIR}/rbac/cluster-scope/role_binding.yaml
+echo -e "\r ✓"
+
+# Update images to adopt dynamic value using params.env
+echo -n ".. Replace each image of the parameter variable 'images'"
+sed 's+kserve/modelmesh$+$(odh-modelmesh)+g' -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
+sed 's+kserve/rest-proxy$+$(odh-mm-rest-proxy)+g' -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
+sed 's+kserve/modelmesh-runtime-adapter$+$(odh-modelmesh-runtime-adapter)+g' -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
+sed '/tag:/d' -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
+
+sed 's+modelmesh-controller:replace$+$(odh-modelmesh-controller)+g' -i ${MODELMESH_CONTROLLER_DIR}/manager/manager.yaml
+
+sed 's+ovms-1:replace$+$(odh-openvino)+g' -i ${MODELMESH_CONTROLLER_DIR}/runtimes/ovms-1.x.yaml
+echo -e "\r ✓"
+
+echo -n ".. Replace replicas of odh modelmesh controller to 3"
+yq e '.spec.replicas = 3' -i ${MODELMESH_CONTROLLER_DIR}/manager/manager.yaml
+echo -e "\r ✓"
+
+echo -n ".. Increase manager limit memory size to 2G"
+yq e '.spec.template.spec.containers[0].resources.limits.memory = "2Gi"' -i  ${MODELMESH_CONTROLLER_DIR}/manager/manager.yaml
+echo -e "\r ✓"
+
+echo -n ".. Add trustAI option into config-defaults.yaml"
+yq eval '."payloadProcessors" = ""'  -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
+echo -e "\r ✓"
+
+echo -n ".. Remove CertManager related from default/kustomization.yaml"
+sed '/certmanager/d' -i ${MODELMESH_CONTROLLER_DIR}/default/kustomization.yaml
+
+licenseNum=$(grep -n vars ${MODELMESH_CONTROLLER_DIR}/default/kustomization.yaml |cut -d':' -f1)
+configMapGeneratorStartLine=$(grep -n configMapGenerator  ${MODELMESH_CONTROLLER_DIR}/default/kustomization.yaml |cut -d':' -f1)
+configMapGeneratorBeforeLine=$((configMapGeneratorStartLine-1))
+sed -i "${licenseNum},${configMapGeneratorBeforeLine}d"  ${MODELMESH_CONTROLLER_DIR}/default/kustomization.yaml
+
+# remove webhookcainjection_patch.yaml
+sed -i '/webhookcainjection_patch.yaml/d'  ${MODELMESH_CONTROLLER_DIR}/default/kustomization.yaml
+echo -e "\r ✓"
+
+echo -n ".. Add serving-cert-secret-name to webhook/service.yaml"
+yq eval '.metadata.annotations."service.beta.openshift.io/serving-cert-secret-name"="modelmesh-webhook-server-cert"' -i  ${MODELMESH_CONTROLLER_DIR}/webhook/service.yaml
+echo -e "\r ✓"
+
+echo -n ".. Add inject-cabundle into webhook/kustomization.yaml"
+yq eval '.commonAnnotations += {"service.beta.openshift.io/inject-cabundle": "true"}' -i ${MODELMESH_CONTROLLER_DIR}/webhook/kustomization.yaml
+
+echo -n ".. Remove namespace "
+sed '/namespace/d' -i  ${MODELMESH_CONTROLLER_DIR}/webhook/service.yaml
+echo -e "\r ✓"

--- a/opendatahub/scripts/gen-manifests/odh_modelmesh_manifests_stable.sh
+++ b/opendatahub/scripts/gen-manifests/odh_modelmesh_manifests_stable.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Update files for Opendatahub
+echo -n ".. Comment out ClusterServingRuntime"
+sed 's+- bases/serving.kserve.io_clusterservingruntimes.yaml+# - bases/serving.kserve.io_clusterservingruntimes.yaml+g' -i ${MODELMESH_CONTROLLER_DIR}/crd/kustomization.yaml
+echo -e "\r ✓"
+
+echo -n ".. Remove builtInServerTypes"
+sed '/builtInServerTypes/,$d' -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
+echo -e "\r ✓"
+
+echo -n ".. Add parameter variable into modelmesh-controller-rolebinding"
+sed 's+modelmesh-controller-rolebinding$+modelmesh-controller-rolebinding-$(mesh-namespace)+g' -i ${MODELMESH_CONTROLLER_DIR}/rbac/cluster-scope/role_binding.yaml
+echo -e "\r ✓"
+
+# Update images to adopt dynamic value using params.env
+echo -n ".. Replace each image of the parameter variable 'images'"
+sed 's+kserve/modelmesh$+$(odh-modelmesh)+g' -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
+sed 's+kserve/rest-proxy$+$(odh-mm-rest-proxy)+g' -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
+sed 's+kserve/modelmesh-runtime-adapter$+$(odh-modelmesh-runtime-adapter)+g' -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
+sed '/tag:/d' -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
+
+sed 's+modelmesh-controller:replace$+$(odh-modelmesh-controller)+g' -i ${MODELMESH_CONTROLLER_DIR}/manager/manager.yaml
+
+sed 's+ovms-1:replace$+$(odh-openvino)+g' -i ${MODELMESH_CONTROLLER_DIR}/runtimes/ovms-1.x.yaml
+echo -e "\r ✓"
+
+echo -n ".. Replace replicas of odh modelmesh controller to 3"
+yq e '.spec.replicas = 3' -i ${MODELMESH_CONTROLLER_DIR}/manager/manager.yaml
+echo -e "\r ✓"
+
+echo -n ".. Increase manager limit memory size to 2G"
+yq e '.spec.template.spec.containers[0].resources.limits.memory = "2Gi"' -i  ${MODELMESH_CONTROLLER_DIR}/manager/manager.yaml
+echo -e "\r ✓"
+
+echo -n ".. Add trustAI option into config-defaults.yaml"
+yq eval '."payloadProcessors" = ""'  -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
+echo -e "\r ✓"
+

--- a/opendatahub/scripts/gen_copy_new_manifests.sh
+++ b/opendatahub/scripts/gen_copy_new_manifests.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+source "$(dirname "$0")/env.sh"
+source "$(dirname "$0")/utils.sh"
+
+export BASE_HOME=/tmp
+export DIR_NAME=modelmesh
+export POSTFIX=$(date  "+%Y%m%d%m%s")
+
+export EXIST_MANIFESTS=model-mesh
+
+function showHelp() {
+  echo "usage: $0 [flags]"
+  echo
+  echo "Flags:"
+  echo "  -p, --stable-manifests         (optional) Use stable manifests. By default, it will use the latest manifests (default false)."
+  echo
+  echo "Copy the generated new odh-manifest to opendatahub/odh-manifests/model-mesh,model-mesh_stable"
+}
+
+while (($# > 0)); do
+  case "$1" in
+  -h | --h | --he | --hel | --help)
+    showHelp
+    exit 2
+    ;;
+  -p | --p | -stable-manifests | --stable-manifests)
+    export EXIST_MANIFESTS=model-mesh_stable
+    ;;       
+  -*)
+    die "Unknown option: '${1}'"
+    ;;       
+  esac
+  shift
+done   
+
+
+if [[ -f  $SCRIPT_DIR/.temp_new_modelmesh_manifests ]]; then
+ export FULL_DIR_NAME=$(cat $SCRIPT_DIR/.temp_new_modelmesh_manifests)
+else
+  FULL_DIR_NAME="$DIR_NAME-$POSTFIX"
+  echo ${FULL_DIR_NAME} > $SCRIPT_DIR/.temp_new_modelmesh_manifests
+fi 
+
+export TARGET_DIR=${BASE_HOME}/${FULL_DIR_NAME}
+
+if [[ ! -d ${TARGET_DIR}/model-mesh_templates ]]; then
+  die "You must execute gen_odh_model_manifests.sh/gen_odh_modelmesh_manifests.sh first"
+else
+  if [[ ! -d ${ODH_MANIFESTS_DIR}/${EXIST_MANIFESTS}_ori ]]; then
+    echo -n ".. Change existing manifest from $EXIST_MANIFESTS to ${EXIST_MANIFESTS}_ori"
+    mv ${ODH_MANIFESTS_DIR}/${EXIST_MANIFESTS} ${ODH_MANIFESTS_DIR}/${EXIST_MANIFESTS}_ori
+  else 
+    die ".. ${EXIST_MANIFESTS}_ori exist, if you want to overwrite it, you need to remove the folder manually"
+  fi
+  echo -e "\r ✓"
+
+  echo -n ".. Copy the patched new manifests into $ODH_MANIFESTS_DIR/$EXIST_MANIFESTS folder for test"
+  cp -R ${TARGET_DIR}/model-mesh_templates  ${ODH_MANIFESTS_DIR}/${EXIST_MANIFESTS}
+fi
+echo -e "\r ✓"

--- a/opendatahub/scripts/gen_odh_model_manifests.sh
+++ b/opendatahub/scripts/gen_odh_model_manifests.sh
@@ -7,24 +7,69 @@ BASE_HOME=/tmp
 DIR_NAME=modelmesh
 POSTFIX=$(date  "+%Y%m%d%m%s")
 
+export EXIST_MANIFESTS=model-mesh
+export ODH_MODEL_CONTROLLER_BRANCH=main
+create_new_dir=false
+
+function showHelp() {
+  echo "usage: $0 [flags]"
+  echo
+  echo "Flags:"
+  echo "  -p, --stable-manifests       (optional) Use stable manifests. By default, it will use the latest manifests (default false)."
+  echo "  -b, --clone-branch           (optional) Use other branch to clone. By default, it will use the main branch (default main)."
+  echo "  -n, --create-new-dir         (optional) Use a new directory. By default, it uses the existing directory if it exists (default false)."
+  echo
+  echo "Generate odh-manifest for odh-model-controller"
+}
+
+while (($# > 0)); do
+  case "$1" in
+  -h | --h | --he | --hel | --help)
+    showHelp
+    exit 2
+    ;;
+  -p | --p | -stable-manifests | --stable-manifests)
+    export EXIST_MANIFESTS=model-mesh_stable
+    ;;       
+  -b | --b | -clone-branch | --clone-branch)
+    shift
+    export ODH_MODEL_CONTROLLER_BRANCH="$1"
+    ;;   
+  -n | --n | -create-new-dir | --create-new-dir)
+    create_new_dir=true
+    ;;        
+  -*)
+    die "Unknown option: '${1}'"
+    ;;       
+  esac
+  shift
+done    
+
+if [[ $ODH_MODEL_CONTROLLER_BRANCH == main ]] && [[ $EXIST_MANIFESTS != model-mesh ]];then
+  die "You set --clone-branch without --stable-manifests. It is usually a mismatch so please check the right branch again(Refer to version file)"
+elif [[ $ODH_MODEL_CONTROLLER_BRANCH != main ]] && [[ $EXIST_MANIFESTS != model-mesh_stable ]];then
+  die "You set --stable-manifests without --clone-branch. It is usually a mismatch so please check the right branch again(Refer to version file)"
+fi
+
+if [[ $create_new_dir == "true" ]]; then
+  rm $SCRIPT_DIR/.temp_new_modelmesh_manifests
+fi
+  
 if [[ -f  $SCRIPT_DIR/.temp_new_modelmesh_manifests ]]; then
- FULL_DIR_NAME=$(cat $SCRIPT_DIR/.temp_new_modelmesh_manifests)
+ export FULL_DIR_NAME=$(cat $SCRIPT_DIR/.temp_new_modelmesh_manifests)
 else
-  FULL_DIR_NAME="$DIR_NAME-$POSTFIX"
+  export FULL_DIR_NAME="$DIR_NAME-$POSTFIX"
   echo ${FULL_DIR_NAME} > $SCRIPT_DIR/.temp_new_modelmesh_manifests
 fi 
 
-TARGET_DIR=${BASE_HOME}/${FULL_DIR_NAME}
-
-ODH_MODEL_CONTROLLER_BRANCH=main
+export TARGET_DIR=${BASE_HOME}/${FULL_DIR_NAME}
+export ODH_MODEL_CONTROLLER_DIR=${TARGET_DIR}/model-mesh_templates/odh-model-controller
 ODH_MODEL_CONTROLLER_GIT=https://github.com/opendatahub-io/odh-model-controller.git
-ODH_MODEL_CONTROLLER_DIR=${TARGET_DIR}/model-mesh_templates/odh-model-controller
 
 info "Generate opendatahub manifest in the ${TARGET_DIR}"
 echo "TARGET DIR: ${TARGET_DIR}"
 echo "--------------------------------------------------"
 echo 
-
 
 if [[ ! -d ${TARGET_DIR} ]]; then
   echo -n ".. Creating a ${TARGET_DIR} folder"
@@ -36,7 +81,7 @@ echo -e "\r ✓"
 cd ${TARGET_DIR}
 
 if [[ ! -d ${TARGET_DIR}/odh-model-controller ]]; then
-  echo -n ".. Git Cloning odh-model-controller to ${TARGET_DIR} folder"
+  echo -n ".. Git Cloning odh-model-controller(branch: $ODH_MODEL_CONTROLLER_BRANCH)  to ${TARGET_DIR} folder"
   git clone  --quiet --branch $ODH_MODEL_CONTROLLER_BRANCH $ODH_MODEL_CONTROLLER_GIT
 else
   echo -n ".. odh-model-controller folder exist,it will reuse the existing folder"
@@ -46,58 +91,35 @@ echo -e "\r ✓"
 # Copy manifests templates
 if [[ ! -d ${TARGET_DIR}/model-mesh_templates ]]; then
   echo -n ".. Copying the model-mesh_templates to ${TARGET_DIR} folder"
-  cp -R $ODH_MANIFESTS_DIR/model-mesh_templates/* ${TARGET_DIR}/model-mesh_templates
-  echo -e "\r ✓"
+  
+  if [[ $EXIST_MANIFESTS == model-mesh ]]; then
+    cp -R $ODH_MANIFESTS_DIR/model-mesh_templates ${TARGET_DIR}/
+  else
+    cp -R $ODH_MANIFESTS_DIR/model-mesh_templates_stable ${TARGET_DIR}/model-mesh_templates
+  fi
 else
   echo -n ".. model-mesh_template folder exist, it will reuse the existing folder"
 fi
+echo -e "\r ✓"
 
 echo -n ".. Copying the odh-model-controller manifests to model-mesh_templates folder"
 cp -R odh-model-controller/config/*  ${ODH_MODEL_CONTROLLER_DIR}/.
 echo -e "\r ✓"
 
-echo -n ".. Delete crd folder"
-rm -rf ${ODH_MODEL_CONTROLLER_DIR}/crd
-echo -e "\r ✓"
-
-echo -n ".. Update kustomization.yaml in default folder"
-if [[ $(grep external ${ODH_MODEL_CONTROLLER_DIR}/default/kustomization.yaml|wc -l) != 0 ]]; then
-  sed '/external/d' -i ${ODH_MODEL_CONTROLLER_DIR}/default/kustomization.yaml
-  sed '/namespace/d' -i ${ODH_MODEL_CONTROLLER_DIR}/default/kustomization.yaml
-  sed '/^$/d' -i ${ODH_MODEL_CONTROLLER_DIR}/default/kustomization.yaml
+# Update manifests based on stable or latest
+if [[ $EXIST_MANIFESTS == model-mesh ]]; then
+  . ${SCRIPT_DIR}/gen-manifests/odh_model_manifests.sh
+else 
+  . ${SCRIPT_DIR}/gen-manifests/odh_model_manifests_stable.sh
 fi
-echo -e "\r ✓"
 
-echo -n ".. Update kustomization.yaml in manager folder"
-sed '/namespace.yaml/d' -i ${ODH_MODEL_CONTROLLER_DIR}/manager/kustomization.yaml
-if [[ $(grep images ${ODH_MODEL_CONTROLLER_DIR}/manager/kustomization.yaml|wc -l) != 0 ]]; then
-  sed '/images/,$d' -i ${ODH_MODEL_CONTROLLER_DIR}/manager/kustomization.yaml
-  sed '$d' -i ${ODH_MODEL_CONTROLLER_DIR}/manager/kustomization.yaml
-fi
-echo -e "\r ✓"
-
-if [[ -f ${ODH_MODEL_CONTROLLER_DIR}/manager/namespace.yaml ]]; then
-  echo -n ".. Delete namespace.yaml file"
-  rm ${ODH_MODEL_CONTROLLER_DIR}/manager/namespace.yaml
-else
-  echo -n ".. namespace.yaml file was already deleted"
-fi
-echo -e "\r ✓"
-
-echo -n ".. Add mesh-namespace into role_binding.yaml in rbac folder"
-if [[ $(grep mesh-namespace ${ODH_MODEL_CONTROLLER_DIR}/rbac/role_binding.yaml|wc -l) == 0 ]]; then
-  sed '$d' -i ${ODH_MODEL_CONTROLLER_DIR}/rbac/role_binding.yaml
-fi
-sed 's+odh-model-controller-rolebinding$+odh-model-controller-rolebinding-$(mesh-namespace)+g' -i ${ODH_MODEL_CONTROLLER_DIR}/rbac/role_binding.yaml
-echo -e "\r ✓"
-
-IS_IDENTICAL=$(diff -r ${TARGET_DIR}/model-mesh_templates/odh-model-controller/ ${ODH_MANIFESTS_DIR}/model-mesh/odh-model-controller/)
+IS_IDENTICAL=$(diff -r ${TARGET_DIR}/model-mesh_templates/odh-model-controller/ ${ODH_MANIFESTS_DIR}/${EXIST_MANIFESTS}/odh-model-controller/)
 
 if [[ z$IS_IDENTICAL == z ]]; then
   success "New Manifests are identical with previous one. You don't need to send any PR to ODH-MANIFESTS repo"
 else
-  info "diff -ruN ${ODH_MANIFESTS_DIR}/model-mesh/odh-model-controller/ ${TARGET_DIR}/model-mesh_templates/odh-model-controller/"
+  info "diff -ruN ${ODH_MANIFESTS_DIR}/${EXIST_MANIFESTS}/odh-model-controller/ ${TARGET_DIR}/model-mesh_templates/odh-model-controller/"
   echo
 
-  die "There are some changes between new manifests and previous one. You should validate the new manifests. If it works, you need to update opendatahub/odh-manifests/model-mesh and opendatahub/odh-manifests/model-mesh_templates"
+  die "There are some changes between new manifests and previous one. You should validate the new manifests. If it works, you need to update opendatahub/odh-manifests/${EXIST_MANIFESTS} and opendatahub/odh-manifests/model-mesh_templates"
 fi

--- a/opendatahub/scripts/gen_odh_modelmesh_manifests.sh
+++ b/opendatahub/scripts/gen_odh_modelmesh_manifests.sh
@@ -3,30 +3,79 @@
 source "$(dirname "$0")/env.sh"
 source "$(dirname "$0")/utils.sh"
 
-BASE_HOME=/tmp
-DIR_NAME=modelmesh
-POSTFIX=$(date  "+%Y%m%d%m%s")
+export BASE_HOME=/tmp
+export DIR_NAME=modelmesh
+export POSTFIX=$(date  "+%Y%m%d%m%s")
+
+export EXIST_MANIFESTS=model-mesh
+export MODELMESH_CONTROLLER_BRANCH=main
+export CURRENT_CONFIG_DIR=$ROOT_DIR/config
+create_new_dir=false
+copy_current_config_dir=false
+
+function showHelp() {
+  echo "usage: $0 [flags]"
+  echo
+  echo "Flags:"
+  echo "  -p, --stable-manifests         (optional) Use stable manifests. By default, it will use the latest manifests (default false)."
+  echo "  -b, --clone-branch             (optional) Use other branch to clone. By default, it will use the main branch (default main)."
+  echo "  -n, --create-new-dir           (optional) Use a new directory. By default, it uses the existing directory if it exists (default false)."
+  echo "  -c, --copy-current-config-dir  (optional) Use a current config directory to compare. By default, it uses the existing config directory instead of cloning git repository (default false)."
+  echo
+  echo "Generate odh-manifest for odh-modelmesh-controller"
+}
+
+while (($# > 0)); do
+  case "$1" in
+  -h | --h | --he | --hel | --help)
+    showHelp
+    exit 2
+    ;;
+  -p | --p | -stable-manifests | --stable-manifests)
+    export EXIST_MANIFESTS=model-mesh_stable
+    ;;       
+  -b | --b | -clone-branch | --clone-branch)
+    shift
+    export MODELMESH_CONTROLLER_BRANCH="$1"
+    ;;   
+  -n | --n | -create-new-dir | --create-new-dir)
+    create_new_dir=true
+    ;;   
+  -c | --c | -copy-current-config-dir | --copy-current-config-dir)
+    copy_current_config_dir=true
+    ;;            
+  -*)
+    die "Unknown option: '${1}'"
+    ;;       
+  esac
+  shift
+done    
+
+if [[ $MODELMESH_CONTROLLER_BRANCH == main ]] && [[ $EXIST_MANIFESTS != model-mesh ]];then
+  die "You set --clone-branch without --stable-manifests. It is usually a mismatch so please check the right branch again(Refer to version file)"
+elif [[ $MODELMESH_CONTROLLER_BRANCH != main ]] && [[ $EXIST_MANIFESTS != model-mesh_stable ]];then
+  die "You set --stable-manifests without --clone-branch. It is usually a mismatch so please check the right branch again(Refer to version file)"
+fi
+
+if [[ $create_new_dir == "true" ]]; then
+  rm $SCRIPT_DIR/.temp_new_modelmesh_manifests
+fi
 
 if [[ -f  $SCRIPT_DIR/.temp_new_modelmesh_manifests ]]; then
- FULL_DIR_NAME=$(cat $SCRIPT_DIR/.temp_new_modelmesh_manifests)
+ export FULL_DIR_NAME=$(cat $SCRIPT_DIR/.temp_new_modelmesh_manifests)
 else
   FULL_DIR_NAME="$DIR_NAME-$POSTFIX"
   echo ${FULL_DIR_NAME} > $SCRIPT_DIR/.temp_new_modelmesh_manifests
 fi 
 
-TARGET_DIR=${BASE_HOME}/${FULL_DIR_NAME}
-
-MODELMESH_CONTROLLER_BRANCH=main
+export TARGET_DIR=${BASE_HOME}/${FULL_DIR_NAME}
+export MODELMESH_CONTROLLER_DIR=${TARGET_DIR}/model-mesh_templates/odh-modelmesh-controller
 MODELMESH_CONTROLLER_GIT=https://github.com/opendatahub-io/modelmesh-serving.git
-MODELMESH_CONTROLLER_DIR=${TARGET_DIR}/model-mesh_templates/odh-modelmesh-controller
-
-copy_current_config_dir=$COPY_CC_DIR
 
 info "Generate opendatahub manifest in the ${TARGET_DIR}"
 echo "TARGET DIR: ${TARGET_DIR}"
 echo "--------------------------------------------------"
 echo 
-
 
 if [[ ! -d ${TARGET_DIR} ]]; then
   echo -n ".. Creating a ${TARGET_DIR} folder"
@@ -39,16 +88,19 @@ cd ${TARGET_DIR}
 
 if [[ ! -d ${TARGET_DIR}/model-mesh_templates ]]; then
   echo -n ".. Copying the model-mesh_templates to ${TARGET_DIR} folder"
-  cp -R $ODH_MANIFESTS_DIR/model-mesh_templates ${TARGET_DIR}/
+  if [[ $EXIST_MANIFESTS == model-mesh ]]; then
+    cp -R $ODH_MANIFESTS_DIR/model-mesh_templates ${TARGET_DIR}/
+  else
+    cp -R $ODH_MANIFESTS_DIR/model-mesh_templates_stable ${TARGET_DIR}/model-mesh_templates
+  fi
 else
   echo -n ".. model-mesh_template folder exist, it will reuse the existing folder"
 fi
 echo -e "\r ✓"
 
-
-if [[ $copy_current_config_dir == "" ]]; then
+if [[ $copy_current_config_dir == "false" ]]; then
   if [[ ! -d ${TARGET_DIR}/odh-modelmesh-controller ]]  then
-      echo -n ".. Git Cloning odh-modelmesh-controller to ${TARGET_DIR} folder"
+      echo -n ".. Git Cloning odh-modelmesh-controller(branch: $MODELMESH_CONTROLLER_BRANCH) to ${TARGET_DIR} folder"
       git clone --quiet --branch $MODELMESH_CONTROLLER_BRANCH $MODELMESH_CONTROLLER_GIT odh-modelmesh-controller
   else
     echo -n ".. odh-modelmesh-controller folder exist,it will reuse the existing folder"
@@ -57,84 +109,29 @@ if [[ $copy_current_config_dir == "" ]]; then
 fi
 
 # Copy manifests templates
-if [[ $copy_current_config_dir == "" ]]; then
+if [[ $copy_current_config_dir == "false" ]]; then
   echo -n ".. Copying the odh-modelmesh-controller manifests to model-mesh_templates folder"
   cp -R odh-modelmesh-controller/config/*  ${MODELMESH_CONTROLLER_DIR}/.
 else 
   echo -n ".. Copy config folder to ${TARGET_DIR} folder"
-  cp -R ${OPENDATAHUB_DIR}/../config/*  ${MODELMESH_CONTROLLER_DIR}/.
+  cp -R ${CURRENT_CONFIG_DIR}/*  ${MODELMESH_CONTROLLER_DIR}/.
 fi
 echo -e "\r ✓"
 
-# Update files for Opendatahub
-echo -n ".. Comment out ClusterServingRuntime"
-sed 's+- bases/serving.kserve.io_clusterservingruntimes.yaml+# - bases/serving.kserve.io_clusterservingruntimes.yaml+g' -i ${MODELMESH_CONTROLLER_DIR}/crd/kustomization.yaml
-echo -e "\r ✓"
+# Update manifests based on stable or latest
+if [[ $EXIST_MANIFESTS == model-mesh ]]; then
+  . ${SCRIPT_DIR}/gen-manifests/odh_modelmesh_manifests.sh
+else 
+  . ${SCRIPT_DIR}/gen-manifests/odh_modelmesh_manifests_stable.sh
+fi
 
-echo -n ".. Remove builtInServerTypes"
-sed '/builtInServerTypes/,$d' -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
-echo -e "\r ✓"
-
-echo -n ".. Add parameter variable into modelmesh-controller-rolebinding"
-sed 's+modelmesh-controller-rolebinding$+modelmesh-controller-rolebinding-$(mesh-namespace)+g' -i ${MODELMESH_CONTROLLER_DIR}/rbac/cluster-scope/role_binding.yaml
-echo -e "\r ✓"
-
-# Update images to adopt dynamic value using params.env
-echo -n ".. Replace each image of the parameter variable 'images'"
-sed 's+kserve/modelmesh$+$(odh-modelmesh)+g' -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
-sed 's+kserve/rest-proxy$+$(odh-mm-rest-proxy)+g' -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
-sed 's+kserve/modelmesh-runtime-adapter$+$(odh-modelmesh-runtime-adapter)+g' -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
-sed '/tag:/d' -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
-
-sed 's+modelmesh-controller:replace$+$(odh-modelmesh-controller)+g' -i ${MODELMESH_CONTROLLER_DIR}/manager/manager.yaml
-
-sed 's+ovms-1:replace$+$(odh-openvino)+g' -i ${MODELMESH_CONTROLLER_DIR}/runtimes/ovms-1.x.yaml
-echo -e "\r ✓"
-
-echo -n ".. Replace replicas of odh modelmesh controller to 3"
-yq e '.spec.replicas = 3' -i ${MODELMESH_CONTROLLER_DIR}/manager/manager.yaml
-echo -e "\r ✓"
-
-echo -n ".. Increase manager limit memory size to 2G"
-yq e '.spec.template.spec.containers[0].resources.limits.memory = "2Gi"' -i  ${MODELMESH_CONTROLLER_DIR}/manager/manager.yaml
-echo -e "\r ✓"
-
-echo -n ".. Add trustAI option into config-defaults.yaml"
-yq eval '."payloadProcessors" = ""'  -i ${MODELMESH_CONTROLLER_DIR}/default/config-defaults.yaml
-echo -e "\r ✓"
-
-echo -n ".. Remove CertManager related from default/kustomization.yaml"
-sed '/certmanager/d' -i ${MODELMESH_CONTROLLER_DIR}/default/kustomization.yaml
-
-licenseNum=$(grep -n vars ${MODELMESH_CONTROLLER_DIR}/default/kustomization.yaml |cut -d':' -f1)
-configMapGeneratorStartLine=$(grep -n configMapGenerator  ${MODELMESH_CONTROLLER_DIR}/default/kustomization.yaml |cut -d':' -f1)
-configMapGeneratorBeforeLine=$((configMapGeneratorStartLine-1))
-sed -i "${licenseNum},${configMapGeneratorBeforeLine}d"  ${MODELMESH_CONTROLLER_DIR}/default/kustomization.yaml
-
-# remove webhookcainjection_patch.yaml
-sed -i '/webhookcainjection_patch.yaml/d'  ${MODELMESH_CONTROLLER_DIR}/default/kustomization.yaml
-echo -e "\r ✓"
-
-echo -n ".. Add serving-cert-secret-name to webhook/service.yaml"
-yq eval '.metadata.annotations."service.beta.openshift.io/serving-cert-secret-name"="modelmesh-webhook-server-cert"' -i  ${MODELMESH_CONTROLLER_DIR}/webhook/service.yaml
-echo -e "\r ✓"
-
-echo -n ".. Add inject-cabundle into webhook/kustomization.yaml"
-yq eval '.commonAnnotations += {"service.beta.openshift.io/inject-cabundle": "true"}' -i ${MODELMESH_CONTROLLER_DIR}/webhook/kustomization.yaml
-
-echo -n ".. Remove namespace "
-sed '/namespace/d' -i  ${MODELMESH_CONTROLLER_DIR}/webhook/service.yaml
-echo -e "\r ✓"
-
-
-
-IS_IDENTICAL=$(diff -r ${TARGET_DIR}/model-mesh_templates/odh-modelmesh-controller/ ${ODH_MANIFESTS_DIR}/model-mesh/odh-modelmesh-controller/)
+IS_IDENTICAL=$(diff -r ${TARGET_DIR}/model-mesh_templates/odh-modelmesh-controller/ ${ODH_MANIFESTS_DIR}/${EXIST_MANIFESTS}/odh-modelmesh-controller/)
 
 if [[ z$IS_IDENTICAL == z ]]; then
   success "New Manifests are identical with previous one. You don't need to send any PR to ODH-MANIFESTS repo"
 else
-  info "diff -ruN ${ODH_MANIFESTS_DIR}/model-mesh/odh-modelmesh-controller/ ${TARGET_DIR}/model-mesh_templates/odh-modelmesh-controller/ "
+  info "diff -ruN ${ODH_MANIFESTS_DIR}/${EXIST_MANIFESTS}/odh-modelmesh-controller/ ${TARGET_DIR}/model-mesh_templates/odh-modelmesh-controller/ "
   echo
   
-  die "There are some changes between new manifests and previous one. You should validate the new manifests. If it works, you need to update opendatahub/odh-manifests/model-mesh and opendatahub/odh-manifests/model-mesh_templates"
+  die "There are some changes between new manifests and previous one. You should validate the new manifests. If it works, you need to update opendatahub/odh-manifests/${EXIST_MANIFESTS} and opendatahub/odh-manifests/model-mesh_templates"
 fi

--- a/opendatahub/scripts/install_odh.sh
+++ b/opendatahub/scripts/install_odh.sh
@@ -72,6 +72,9 @@ while (($# > 0)); do
     ;;   
   -p | --p | -stable-manifests | --stable-manifests)
     stable_manifests=true
+    if [[ $repo_uri != "local" ]];then
+      die "Do NOT allow to set '--stable-manifests=true' and '--repo-uri=remote' together"
+    fi
     ;;         
   -*)
     die "Unknown option: '${1}'"


### PR DESCRIPTION
#### Motivation
ModelServing utilizes the kserve/modelmesh manifest as a base but makes some modifications before using it. However, these modifications require mostly manual intervention. Nevertheless, automating some parts of the process can still be helpful. In this pull request (PR),  scripts and templates have been added to generate manifests for the main/stable branches.

This is not source change so it does not need to test.

#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [X] Unit tests pass locally
- [X] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [X] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
