### PR TITLE
Add pod anti-affinity to odh-model-controller manifests

### DIFF
--- a/opendatahub/odh-manifests/model-mesh/odh-model-controller/manager/manager.yaml
+++ b/opendatahub/odh-manifests/model-mesh/odh-model-controller/manager/manager.yaml
@@ -18,6 +18,18 @@ spec:
         control-plane: odh-model-controller
         app: odh-model-controller
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: control-plane
+                      operator: In
+                      values:
+                        - odh-model-controller
+                topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
       containers:

--- a/opendatahub/odh-manifests/model-mesh_stable/odh-model-controller/manager/manager.yaml
+++ b/opendatahub/odh-manifests/model-mesh_stable/odh-model-controller/manager/manager.yaml
@@ -18,6 +18,18 @@ spec:
         control-plane: odh-model-controller
         app: odh-model-controller
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: control-plane
+                      operator: In
+                      values:
+                        - odh-model-controller
+                topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
       containers:


### PR DESCRIPTION
#### Motivation

See https://github.com/opendatahub-io/odh-model-controller/pull/51

#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [x] Unit tests pass locally
- [x] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
