### PR TITLE
fix RHODS-9627 - rollback label

### DIFF
--- a/opendatahub/odh-manifests/model-mesh/base/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh/base/kustomization.yaml
@@ -4,8 +4,6 @@ resources:
   - ../odh-modelmesh-controller/overlays/odh
   - ../odh-model-controller/overlays/odh
 
-commonLabels:
-  app.kubernetes.io/part-of: model-mesh
 namespace: opendatahub
 configMapGenerator:
   - envs:

--- a/opendatahub/odh-manifests/model-mesh/odh-model-controller/overlays/odh/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh/odh-model-controller/overlays/odh/kustomization.yaml
@@ -5,8 +5,6 @@ resources:
 
 patchesStrategicMerge:
   - odh_model_controller_manager_patch.yaml
-commonLabels:
-  app.kubernetes.io/managed-by: odh-model-controller
 
 configurations:
   - params.yaml

--- a/opendatahub/odh-manifests/model-mesh/odh-modelmesh-controller/overlays/odh/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh/odh-modelmesh-controller/overlays/odh/kustomization.yaml
@@ -9,7 +9,8 @@ resources:
   - ./manager
 
 commonLabels:
-  app.kubernetes.io/managed-by: modelmesh-controller
+  app: model-mesh
+  app.kubernetes.io/part-of: model-mesh
 
 configurations:
   - params.yaml

--- a/opendatahub/odh-manifests/model-mesh_stable/base/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_stable/base/kustomization.yaml
@@ -4,8 +4,6 @@ resources:
   - ../odh-modelmesh-controller/overlays/odh
   - ../odh-model-controller/overlays/odh
 
-commonLabels:
-  app.kubernetes.io/part-of: model-mesh
 namespace: opendatahub
 configMapGenerator:
   - envs:

--- a/opendatahub/odh-manifests/model-mesh_stable/odh-model-controller/overlays/odh/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_stable/odh-model-controller/overlays/odh/kustomization.yaml
@@ -5,8 +5,6 @@ resources:
 
 patchesStrategicMerge:
   - odh_model_controller_manager_patch.yaml
-commonLabels:
-  app.kubernetes.io/managed-by: odh-model-controller
 
 configurations:
   - params.yaml

--- a/opendatahub/odh-manifests/model-mesh_stable/odh-modelmesh-controller/overlays/odh/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_stable/odh-modelmesh-controller/overlays/odh/kustomization.yaml
@@ -9,7 +9,8 @@ resources:
   - ./manager
 
 commonLabels:
-  app.kubernetes.io/managed-by: modelmesh-controller
+  app: model-mesh
+  app.kubernetes.io/part-of: model-mesh
 
 configurations:
   - params.yaml


### PR DESCRIPTION
#### Motivation
With the new manifests, it tries to use a new label to explain components but it causes an upgrade fail because the spec.selector in the deployment is immutable.

In order to upgrade properly, I rollback the label.

#### Result
It does not impact a fresh installation but it will help to upgrade the previous modelmesh component.

#### PR checklist
It does not need tests because it does not impact to a fresh installation.