### PR TITLE
ose-oauth-proxy image unified to be based on v4.10 tag

### DIFF
--- a/config/internal/base/deployment.yaml.tmpl
+++ b/config/internal/base/deployment.yaml.tmpl
@@ -136,7 +136,7 @@ spec:
             - '--openshift-delegate-urls={"/": {"namespace": "{{.AuthNamespace}}", "resource": "services", "verb": "get"}}'
             - '--openshift-sar={"namespace": "{{.AuthNamespace}}", "resource": "services", "verb": "get"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-          image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
+          image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33
           ports:
             - containerPort: 8443
               name: https


### PR DESCRIPTION
#### Motivation

Make ose-oauth-proxy container version or sha256 digest reference consistent across all components e.g. odh-dashboard.

Will update in all places affected.

https://github.com/search?q=repo%3Aopendatahub-io%2Fmodelmesh-serving%20ose-oauth-proxy&type=code

Related to PR in odh-manifests to unify image https://github.com/opendatahub-io/odh-manifests/pull/869

Agree on v4.10

registry.redhat.io/openshift4/ose-oauth-proxy@sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33

Since ose-oauth-proxy tag reference image behind, the digest, regardless which openshift 4 minor version, changes regularly. Thus, and to be compatible with restricted network environment ImageContentSourcePolicy as well with node image caching with imagePullPolicy: IfNotPresent, change to digest notation.

Latest manifest link digest for v4.10 from July 6 2023 

https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy/5cdb2133bed8bd5717d5ae64?architecture=amd64&tag=v4.10.0-202306170106.p0.g799d414.assembly.stream&push_date=1688610772000&container-tabs=gti

included in this PR.

alternative way with downloading, just to show it is in fact the most current v4.10 digest:

```
docker pull registry.redhat.io/openshift4/ose-oauth-proxy:v4.10
v4.10: Pulling from openshift4/ose-oauth-proxy
1df162fae087: Already exists 
d20a374ee8f7: Already exists 
e88a8f7a57fc: Pull complete 
dcbbfecd111e: Pull complete 
Digest: sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33
Status: Downloaded newer image for registry.redhat.io/openshift4/ose-oauth-proxy:v4.10
registry.redhat.io/openshift4/ose-oauth-proxy:v4.10
```

#### Modifications
different digest in template

#### Result
same image for ose-oauth-proxy as in all other components

#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
