### PR TITLE
Manifest updates resulting from #174

### DIFF
--- a/opendatahub/odh-manifests/model-mesh/odh-modelmesh-controller/crd/bases/serving.kserve.io_clusterservingruntimes.yaml
+++ b/opendatahub/odh-manifests/model-mesh/odh-modelmesh-controller/crd/bases/serving.kserve.io_clusterservingruntimes.yaml
@@ -1,10 +1,10 @@
-# Copied from https://github.com/kserve/kserve/blob/v0.11.0-rc0/config/crd/serving.kserve.io_clusterservingruntimes.yaml
+# Copied from https://github.com/kserve/kserve/blob/v0.11.0/config/crd/serving.kserve.io_clusterservingruntimes.yaml
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: clusterservingruntimes.serving.kserve.io
 spec:
   group: serving.kserve.io
@@ -82,6 +82,7 @@ spec:
                                       type: object
                                     type: array
                                 type: object
+                                x-kubernetes-map-type: atomic
                               weight:
                                 format: int32
                                 type: integer
@@ -128,10 +129,12 @@ spec:
                                       type: object
                                     type: array
                                 type: object
+                                x-kubernetes-map-type: atomic
                               type: array
                           required:
                             - nodeSelectorTerms
                           type: object
+                          x-kubernetes-map-type: atomic
                       type: object
                     podAffinity:
                       properties:
@@ -163,6 +166,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -186,6 +190,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     items:
                                       type: string
@@ -229,6 +234,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                               namespaceSelector:
                                 properties:
                                   matchExpressions:
@@ -252,6 +258,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                               namespaces:
                                 items:
                                   type: string
@@ -293,6 +300,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -316,6 +324,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     items:
                                       type: string
@@ -359,6 +368,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                               namespaceSelector:
                                 properties:
                                   matchExpressions:
@@ -382,6 +392,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                               namespaces:
                                 items:
                                   type: string
@@ -420,6 +431,7 @@ spec:
                                 required:
                                   - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               fieldRef:
                                 properties:
                                   apiVersion:
@@ -429,6 +441,7 @@ spec:
                                 required:
                                   - fieldPath
                                 type: object
+                                x-kubernetes-map-type: atomic
                               resourceFieldRef:
                                 properties:
                                   containerName:
@@ -444,6 +457,7 @@ spec:
                                 required:
                                   - resource
                                 type: object
+                                x-kubernetes-map-type: atomic
                               secretKeyRef:
                                 properties:
                                   key:
@@ -455,6 +469,7 @@ spec:
                                 required:
                                   - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                         required:
                           - name
@@ -500,6 +515,7 @@ spec:
                                   required:
                                     - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 fieldRef:
                                   properties:
                                     apiVersion:
@@ -509,6 +525,7 @@ spec:
                                   required:
                                     - fieldPath
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 resourceFieldRef:
                                   properties:
                                     containerName:
@@ -524,6 +541,7 @@ spec:
                                   required:
                                     - resource
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 secretKeyRef:
                                   properties:
                                     key:
@@ -535,6 +553,7 @@ spec:
                                   required:
                                     - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                           required:
                             - name
@@ -550,6 +569,7 @@ spec:
                                 optional:
                                   type: boolean
                               type: object
+                              x-kubernetes-map-type: atomic
                             prefix:
                               type: string
                             secretRef:
@@ -559,6 +579,7 @@ spec:
                                 optional:
                                   type: boolean
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         type: array
                       image:
@@ -762,8 +783,8 @@ spec:
                             name:
                               type: string
                             protocol:
-                              type: string
                               default: TCP
+                              type: string
                           required:
                             - containerPort
                           type: object
@@ -852,6 +873,18 @@ spec:
                         type: object
                       resources:
                         properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
                           limits:
                             additionalProperties:
                               anyOf:
@@ -1070,6 +1103,7 @@ spec:
                       name:
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 labels:
                   additionalProperties:
@@ -1185,6 +1219,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           user:
                             type: string
                         required:
@@ -1201,6 +1236,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           volumeID:
                             type: string
                         required:
@@ -1231,6 +1267,7 @@ spec:
                           optional:
                             type: boolean
                         type: object
+                        x-kubernetes-map-type: atomic
                       csi:
                         properties:
                           driver:
@@ -1242,6 +1279,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           readOnly:
                             type: boolean
                           volumeAttributes:
@@ -1268,6 +1306,7 @@ spec:
                                   required:
                                     - fieldPath
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 mode:
                                   format: int32
                                   type: integer
@@ -1288,6 +1327,7 @@ spec:
                                   required:
                                     - resource
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               required:
                                 - path
                               type: object
@@ -1328,6 +1368,7 @@ spec:
                                       - kind
                                       - name
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   dataSourceRef:
                                     properties:
                                       apiGroup:
@@ -1336,12 +1377,26 @@ spec:
                                         type: string
                                       name:
                                         type: string
+                                      namespace:
+                                        type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
                                     properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
                                       limits:
                                         additionalProperties:
                                           anyOf:
@@ -1382,6 +1437,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   storageClassName:
                                     type: string
                                   volumeMode:
@@ -1428,6 +1484,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                         required:
                           - driver
                         type: object
@@ -1512,6 +1569,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           targetPortal:
                             type: string
                         required:
@@ -1592,6 +1650,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 downwardAPI:
                                   properties:
                                     items:
@@ -1606,6 +1665,7 @@ spec:
                                             required:
                                               - fieldPath
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           mode:
                                             format: int32
                                             type: integer
@@ -1626,6 +1686,7 @@ spec:
                                             required:
                                               - resource
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                         required:
                                           - path
                                         type: object
@@ -1653,6 +1714,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 serviceAccountToken:
                                   properties:
                                     audience:
@@ -1707,6 +1769,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           user:
                             type: string
                         required:
@@ -1728,6 +1791,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           sslEnabled:
                             type: boolean
                           storageMode:
@@ -1779,6 +1843,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           volumeName:
                             type: string
                           volumeNamespace:
@@ -1810,9 +1875,3 @@ spec:
       served: true
       storage: true
       subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/opendatahub/odh-manifests/model-mesh/odh-modelmesh-controller/crd/bases/serving.kserve.io_inferenceservices.yaml
+++ b/opendatahub/odh-manifests/model-mesh/odh-modelmesh-controller/crd/bases/serving.kserve.io_inferenceservices.yaml
@@ -1,10 +1,10 @@
-# Copied from https://github.com/kserve/kserve/blob/v0.11.0-rc0/config/crd/serving.kserve.io_inferenceservices.yaml
+# Copied from https://github.com/kserve/kserve/blob/v0.11.0/config/crd/serving.kserve.io_inferenceservices.yaml
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: inferenceservices.serving.kserve.io
 spec:
   group: serving.kserve.io
@@ -98,6 +98,7 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   weight:
                                     format: int32
                                     type: integer
@@ -144,10 +145,12 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   type: array
                               required:
                                 - nodeSelectorTerms
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
                           properties:
@@ -179,6 +182,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -202,6 +206,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -245,6 +250,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -268,6 +274,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     items:
                                       type: string
@@ -309,6 +316,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -332,6 +340,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -375,6 +384,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -398,6 +408,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     items:
                                       type: string
@@ -444,6 +455,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     properties:
                                       apiVersion:
@@ -453,6 +465,7 @@ spec:
                                     required:
                                       - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -468,6 +481,7 @@ spec:
                                     required:
                                       - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     properties:
                                       key:
@@ -479,6 +493,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                               - name
@@ -494,6 +509,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 type: string
                               secretRef:
@@ -503,6 +519,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -702,8 +719,8 @@ spec:
                               name:
                                 type: string
                               protocol:
-                                type: string
                                 default: TCP
+                                type: string
                             required:
                               - containerPort
                             type: object
@@ -788,6 +805,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -1008,6 +1037,10 @@ spec:
                         workingDir:
                           type: string
                       type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
                     art:
                       properties:
                         args:
@@ -1042,6 +1075,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     properties:
                                       apiVersion:
@@ -1051,6 +1085,7 @@ spec:
                                     required:
                                       - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -1066,6 +1101,7 @@ spec:
                                     required:
                                       - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     properties:
                                       key:
@@ -1077,6 +1113,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                               - name
@@ -1092,6 +1129,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 type: string
                               secretRef:
@@ -1101,6 +1139,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -1300,8 +1339,8 @@ spec:
                               name:
                                 type: string
                               protocol:
-                                type: string
                                 default: TCP
+                                type: string
                             required:
                               - containerPort
                             type: object
@@ -1386,6 +1425,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -1654,6 +1705,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     fieldRef:
                                       properties:
                                         apiVersion:
@@ -1663,6 +1715,7 @@ spec:
                                       required:
                                         - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     resourceFieldRef:
                                       properties:
                                         containerName:
@@ -1678,6 +1731,7 @@ spec:
                                       required:
                                         - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     secretKeyRef:
                                       properties:
                                         key:
@@ -1689,6 +1743,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                               required:
                                 - name
@@ -1704,6 +1759,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 prefix:
                                   type: string
                                 secretRef:
@@ -1713,6 +1769,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             type: array
                           image:
@@ -1914,8 +1971,8 @@ spec:
                                 name:
                                   type: string
                                 protocol:
-                                  type: string
                                   default: TCP
+                                  type: string
                               required:
                                 - containerPort
                               type: object
@@ -2002,6 +2059,18 @@ spec:
                             type: object
                           resources:
                             properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
                               limits:
                                 additionalProperties:
                                   anyOf:
@@ -2247,6 +2316,8 @@ spec:
                       type: boolean
                     hostPID:
                       type: boolean
+                    hostUsers:
+                      type: boolean
                     hostname:
                       type: string
                     imagePullSecrets:
@@ -2255,6 +2326,7 @@ spec:
                           name:
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       type: array
                     initContainers:
                       items:
@@ -2287,6 +2359,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     fieldRef:
                                       properties:
                                         apiVersion:
@@ -2296,6 +2369,7 @@ spec:
                                       required:
                                         - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     resourceFieldRef:
                                       properties:
                                         containerName:
@@ -2311,6 +2385,7 @@ spec:
                                       required:
                                         - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     secretKeyRef:
                                       properties:
                                         key:
@@ -2322,6 +2397,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                               required:
                                 - name
@@ -2337,6 +2413,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 prefix:
                                   type: string
                                 secretRef:
@@ -2346,6 +2423,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             type: array
                           image:
@@ -2549,8 +2627,8 @@ spec:
                                 name:
                                   type: string
                                 protocol:
-                                  type: string
                                   default: TCP
+                                  type: string
                               required:
                                 - containerPort
                               type: object
@@ -2639,6 +2717,18 @@ spec:
                             type: object
                           resources:
                             properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
                               limits:
                                 additionalProperties:
                                   anyOf:
@@ -2843,6 +2933,10 @@ spec:
                           - name
                         type: object
                       type: array
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     logger:
                       properties:
                         mode:
@@ -2894,6 +2988,25 @@ spec:
                           - conditionType
                         type: object
                       type: array
+                    resourceClaims:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          source:
+                            properties:
+                              resourceClaimName:
+                                type: string
+                              resourceClaimTemplateName:
+                                type: string
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     restartPolicy:
                       type: string
                     runtimeClassName:
@@ -2909,6 +3022,18 @@ spec:
                       type: integer
                     schedulerName:
                       type: string
+                    schedulingGates:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     securityContext:
                       properties:
                         fsGroup:
@@ -3031,9 +3156,22 @@ spec:
                                   type: string
                                 type: object
                             type: object
+                            x-kubernetes-map-type: atomic
+                          matchLabelKeys:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
                           maxSkew:
                             format: int32
                             type: integer
+                          minDomains:
+                            format: int32
+                            type: integer
+                          nodeAffinityPolicy:
+                            type: string
+                          nodeTaintsPolicy:
+                            type: string
                           topologyKey:
                             type: string
                           whenUnsatisfiable:
@@ -3112,6 +3250,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               user:
                                 type: string
                             required:
@@ -3128,6 +3267,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               volumeID:
                                 type: string
                             required:
@@ -3158,6 +3298,7 @@ spec:
                               optional:
                                 type: boolean
                             type: object
+                            x-kubernetes-map-type: atomic
                           csi:
                             properties:
                               driver:
@@ -3169,6 +3310,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               readOnly:
                                 type: boolean
                               volumeAttributes:
@@ -3195,6 +3337,7 @@ spec:
                                       required:
                                         - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     mode:
                                       format: int32
                                       type: integer
@@ -3215,6 +3358,7 @@ spec:
                                       required:
                                         - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   required:
                                     - path
                                   type: object
@@ -3255,6 +3399,7 @@ spec:
                                           - kind
                                           - name
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       dataSourceRef:
                                         properties:
                                           apiGroup:
@@ -3263,12 +3408,26 @@ spec:
                                             type: string
                                           name:
                                             type: string
+                                          namespace:
+                                            type: string
                                         required:
                                           - kind
                                           - name
                                         type: object
                                       resources:
                                         properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
                                           limits:
                                             additionalProperties:
                                               anyOf:
@@ -3309,6 +3468,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       storageClassName:
                                         type: string
                                       volumeMode:
@@ -3355,6 +3515,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                             required:
                               - driver
                             type: object
@@ -3439,6 +3600,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               targetPortal:
                                 type: string
                             required:
@@ -3519,6 +3681,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     downwardAPI:
                                       properties:
                                         items:
@@ -3533,6 +3696,7 @@ spec:
                                                 required:
                                                   - fieldPath
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               mode:
                                                 format: int32
                                                 type: integer
@@ -3553,6 +3717,7 @@ spec:
                                                 required:
                                                   - resource
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                             required:
                                               - path
                                             type: object
@@ -3580,6 +3745,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     serviceAccountToken:
                                       properties:
                                         audience:
@@ -3634,6 +3800,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               user:
                                 type: string
                             required:
@@ -3655,6 +3822,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               sslEnabled:
                                 type: boolean
                               storageMode:
@@ -3706,6 +3874,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               volumeName:
                                 type: string
                               volumeNamespace:
@@ -3776,6 +3945,7 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   weight:
                                     format: int32
                                     type: integer
@@ -3822,10 +3992,12 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   type: array
                               required:
                                 - nodeSelectorTerms
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
                           properties:
@@ -3857,6 +4029,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -3880,6 +4053,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -3923,6 +4097,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -3946,6 +4121,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     items:
                                       type: string
@@ -3987,6 +4163,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -4010,6 +4187,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -4053,6 +4231,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -4076,6 +4255,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     items:
                                       type: string
@@ -4087,6 +4267,10 @@ spec:
                                 type: object
                               type: array
                           type: object
+                      type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
                       type: object
                     automountServiceAccountToken:
                       type: boolean
@@ -4136,6 +4320,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     fieldRef:
                                       properties:
                                         apiVersion:
@@ -4145,6 +4330,7 @@ spec:
                                       required:
                                         - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     resourceFieldRef:
                                       properties:
                                         containerName:
@@ -4160,6 +4346,7 @@ spec:
                                       required:
                                         - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     secretKeyRef:
                                       properties:
                                         key:
@@ -4171,6 +4358,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                               required:
                                 - name
@@ -4186,6 +4374,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 prefix:
                                   type: string
                                 secretRef:
@@ -4195,6 +4384,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             type: array
                           image:
@@ -4396,8 +4586,8 @@ spec:
                                 name:
                                   type: string
                                 protocol:
-                                  type: string
                                   default: TCP
+                                  type: string
                               required:
                                 - containerPort
                               type: object
@@ -4484,6 +4674,18 @@ spec:
                             type: object
                           resources:
                             properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
                               limits:
                                 additionalProperties:
                                   anyOf:
@@ -4729,6 +4931,8 @@ spec:
                       type: boolean
                     hostPID:
                       type: boolean
+                    hostUsers:
+                      type: boolean
                     hostname:
                       type: string
                     imagePullSecrets:
@@ -4737,6 +4941,7 @@ spec:
                           name:
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       type: array
                     initContainers:
                       items:
@@ -4769,6 +4974,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     fieldRef:
                                       properties:
                                         apiVersion:
@@ -4778,6 +4984,7 @@ spec:
                                       required:
                                         - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     resourceFieldRef:
                                       properties:
                                         containerName:
@@ -4793,6 +5000,7 @@ spec:
                                       required:
                                         - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     secretKeyRef:
                                       properties:
                                         key:
@@ -4804,6 +5012,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                               required:
                                 - name
@@ -4819,6 +5028,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 prefix:
                                   type: string
                                 secretRef:
@@ -4828,6 +5038,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             type: array
                           image:
@@ -5031,8 +5242,8 @@ spec:
                                 name:
                                   type: string
                                 protocol:
-                                  type: string
                                   default: TCP
+                                  type: string
                               required:
                                 - containerPort
                               type: object
@@ -5121,6 +5332,18 @@ spec:
                             type: object
                           resources:
                             properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
                               limits:
                                 additionalProperties:
                                   anyOf:
@@ -5325,6 +5548,10 @@ spec:
                           - name
                         type: object
                       type: array
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     lightgbm:
                       properties:
                         args:
@@ -5355,6 +5582,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     properties:
                                       apiVersion:
@@ -5364,6 +5592,7 @@ spec:
                                     required:
                                       - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -5379,6 +5608,7 @@ spec:
                                     required:
                                       - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     properties:
                                       key:
@@ -5390,6 +5620,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                               - name
@@ -5405,6 +5636,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 type: string
                               secretRef:
@@ -5414,6 +5646,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -5613,8 +5846,8 @@ spec:
                               name:
                                 type: string
                               protocol:
-                                type: string
                                 default: TCP
+                                type: string
                             required:
                               - containerPort
                             type: object
@@ -5701,6 +5934,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -5964,6 +6209,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     properties:
                                       apiVersion:
@@ -5973,6 +6219,7 @@ spec:
                                     required:
                                       - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -5988,6 +6235,7 @@ spec:
                                     required:
                                       - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     properties:
                                       key:
@@ -5999,6 +6247,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                               - name
@@ -6014,6 +6263,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 type: string
                               secretRef:
@@ -6023,6 +6273,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -6231,8 +6482,8 @@ spec:
                               name:
                                 type: string
                               protocol:
-                                type: string
                                 default: TCP
+                                type: string
                             required:
                               - containerPort
                             type: object
@@ -6319,6 +6570,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -6576,6 +6839,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     properties:
                                       apiVersion:
@@ -6585,6 +6849,7 @@ spec:
                                     required:
                                       - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -6600,6 +6865,7 @@ spec:
                                     required:
                                       - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     properties:
                                       key:
@@ -6611,6 +6877,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                               - name
@@ -6626,6 +6893,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 type: string
                               secretRef:
@@ -6635,6 +6903,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -6834,8 +7103,8 @@ spec:
                               name:
                                 type: string
                               protocol:
-                                type: string
                                 default: TCP
+                                type: string
                             required:
                               - containerPort
                             type: object
@@ -6922,6 +7191,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -7183,6 +7464,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     properties:
                                       apiVersion:
@@ -7192,6 +7474,7 @@ spec:
                                     required:
                                       - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -7207,6 +7490,7 @@ spec:
                                     required:
                                       - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     properties:
                                       key:
@@ -7218,6 +7502,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                               - name
@@ -7233,6 +7518,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 type: string
                               secretRef:
@@ -7242,6 +7528,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -7441,8 +7728,8 @@ spec:
                               name:
                                 type: string
                               protocol:
-                                type: string
                                 default: TCP
+                                type: string
                             required:
                               - containerPort
                             type: object
@@ -7529,6 +7816,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -7777,6 +8076,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     properties:
                                       apiVersion:
@@ -7786,6 +8086,7 @@ spec:
                                     required:
                                       - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -7801,6 +8102,7 @@ spec:
                                     required:
                                       - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     properties:
                                       key:
@@ -7812,6 +8114,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                               - name
@@ -7827,6 +8130,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 type: string
                               secretRef:
@@ -7836,6 +8140,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -8035,8 +8340,8 @@ spec:
                               name:
                                 type: string
                               protocol:
-                                type: string
                                 default: TCP
+                                type: string
                             required:
                               - containerPort
                             type: object
@@ -8123,6 +8428,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -8378,6 +8695,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     properties:
                                       apiVersion:
@@ -8387,6 +8705,7 @@ spec:
                                     required:
                                       - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -8402,6 +8721,7 @@ spec:
                                     required:
                                       - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     properties:
                                       key:
@@ -8413,6 +8733,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                               - name
@@ -8428,6 +8749,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 type: string
                               secretRef:
@@ -8437,6 +8759,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -8636,8 +8959,8 @@ spec:
                               name:
                                 type: string
                               protocol:
-                                type: string
                                 default: TCP
+                                type: string
                             required:
                               - containerPort
                             type: object
@@ -8724,6 +9047,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -8951,6 +9286,25 @@ spec:
                           - conditionType
                         type: object
                       type: array
+                    resourceClaims:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          source:
+                            properties:
+                              resourceClaimName:
+                                type: string
+                              resourceClaimTemplateName:
+                                type: string
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     restartPolicy:
                       type: string
                     runtimeClassName:
@@ -8966,6 +9320,18 @@ spec:
                       type: integer
                     schedulerName:
                       type: string
+                    schedulingGates:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     securityContext:
                       properties:
                         fsGroup:
@@ -9068,6 +9434,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     properties:
                                       apiVersion:
@@ -9077,6 +9444,7 @@ spec:
                                     required:
                                       - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -9092,6 +9460,7 @@ spec:
                                     required:
                                       - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     properties:
                                       key:
@@ -9103,6 +9472,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                               - name
@@ -9118,6 +9488,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 type: string
                               secretRef:
@@ -9127,6 +9498,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -9326,8 +9698,8 @@ spec:
                               name:
                                 type: string
                               protocol:
-                                type: string
                                 default: TCP
+                                type: string
                             required:
                               - containerPort
                             type: object
@@ -9414,6 +9786,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -9664,6 +10048,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     properties:
                                       apiVersion:
@@ -9673,6 +10058,7 @@ spec:
                                     required:
                                       - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -9688,6 +10074,7 @@ spec:
                                     required:
                                       - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     properties:
                                       key:
@@ -9699,6 +10086,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                               - name
@@ -9714,6 +10102,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 type: string
                               secretRef:
@@ -9723,6 +10112,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -9922,8 +10312,8 @@ spec:
                               name:
                                 type: string
                               protocol:
-                                type: string
                                 default: TCP
+                                type: string
                             required:
                               - containerPort
                             type: object
@@ -10010,6 +10400,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -10276,9 +10678,22 @@ spec:
                                   type: string
                                 type: object
                             type: object
+                            x-kubernetes-map-type: atomic
+                          matchLabelKeys:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
                           maxSkew:
                             format: int32
                             type: integer
+                          minDomains:
+                            format: int32
+                            type: integer
+                          nodeAffinityPolicy:
+                            type: string
+                          nodeTaintsPolicy:
+                            type: string
                           topologyKey:
                             type: string
                           whenUnsatisfiable:
@@ -10323,6 +10738,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     properties:
                                       apiVersion:
@@ -10332,6 +10748,7 @@ spec:
                                     required:
                                       - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -10347,6 +10764,7 @@ spec:
                                     required:
                                       - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     properties:
                                       key:
@@ -10358,6 +10776,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                               - name
@@ -10373,6 +10792,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 type: string
                               secretRef:
@@ -10382,6 +10802,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -10581,8 +11002,8 @@ spec:
                               name:
                                 type: string
                               protocol:
-                                type: string
                                 default: TCP
+                                type: string
                             required:
                               - containerPort
                             type: object
@@ -10669,6 +11090,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -10951,6 +11384,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               user:
                                 type: string
                             required:
@@ -10967,6 +11401,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               volumeID:
                                 type: string
                             required:
@@ -10997,6 +11432,7 @@ spec:
                               optional:
                                 type: boolean
                             type: object
+                            x-kubernetes-map-type: atomic
                           csi:
                             properties:
                               driver:
@@ -11008,6 +11444,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               readOnly:
                                 type: boolean
                               volumeAttributes:
@@ -11034,6 +11471,7 @@ spec:
                                       required:
                                         - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     mode:
                                       format: int32
                                       type: integer
@@ -11054,6 +11492,7 @@ spec:
                                       required:
                                         - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   required:
                                     - path
                                   type: object
@@ -11094,6 +11533,7 @@ spec:
                                           - kind
                                           - name
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       dataSourceRef:
                                         properties:
                                           apiGroup:
@@ -11102,12 +11542,26 @@ spec:
                                             type: string
                                           name:
                                             type: string
+                                          namespace:
+                                            type: string
                                         required:
                                           - kind
                                           - name
                                         type: object
                                       resources:
                                         properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
                                           limits:
                                             additionalProperties:
                                               anyOf:
@@ -11148,6 +11602,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       storageClassName:
                                         type: string
                                       volumeMode:
@@ -11194,6 +11649,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                             required:
                               - driver
                             type: object
@@ -11278,6 +11734,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               targetPortal:
                                 type: string
                             required:
@@ -11358,6 +11815,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     downwardAPI:
                                       properties:
                                         items:
@@ -11372,6 +11830,7 @@ spec:
                                                 required:
                                                   - fieldPath
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               mode:
                                                 format: int32
                                                 type: integer
@@ -11392,6 +11851,7 @@ spec:
                                                 required:
                                                   - resource
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                             required:
                                               - path
                                             type: object
@@ -11419,6 +11879,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     serviceAccountToken:
                                       properties:
                                         audience:
@@ -11473,6 +11934,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               user:
                                 type: string
                             required:
@@ -11494,6 +11956,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               sslEnabled:
                                 type: boolean
                               storageMode:
@@ -11545,6 +12008,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               volumeName:
                                 type: string
                               volumeNamespace:
@@ -11597,6 +12061,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
                                     properties:
                                       apiVersion:
@@ -11606,6 +12071,7 @@ spec:
                                     required:
                                       - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
                                     properties:
                                       containerName:
@@ -11621,6 +12087,7 @@ spec:
                                     required:
                                       - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     properties:
                                       key:
@@ -11632,6 +12099,7 @@ spec:
                                     required:
                                       - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                               - name
@@ -11647,6 +12115,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 type: string
                               secretRef:
@@ -11656,6 +12125,7 @@ spec:
                                   optional:
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         image:
@@ -11855,8 +12325,8 @@ spec:
                               name:
                                 type: string
                               protocol:
-                                type: string
                                 default: TCP
+                                type: string
                             required:
                               - containerPort
                             type: object
@@ -11943,6 +12413,18 @@ spec:
                           type: object
                         resources:
                           properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             limits:
                               additionalProperties:
                                 anyOf:
@@ -12209,6 +12691,7 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   weight:
                                     format: int32
                                     type: integer
@@ -12255,10 +12738,12 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   type: array
                               required:
                                 - nodeSelectorTerms
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
                           properties:
@@ -12290,6 +12775,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -12313,6 +12799,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -12356,6 +12843,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -12379,6 +12867,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     items:
                                       type: string
@@ -12420,6 +12909,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
                                         properties:
                                           matchExpressions:
@@ -12443,6 +12933,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
                                         items:
                                           type: string
@@ -12486,6 +12977,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -12509,6 +13001,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     items:
                                       type: string
@@ -12520,6 +13013,10 @@ spec:
                                 type: object
                               type: array
                           type: object
+                      type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
                       type: object
                     automountServiceAccountToken:
                       type: boolean
@@ -12569,6 +13066,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     fieldRef:
                                       properties:
                                         apiVersion:
@@ -12578,6 +13076,7 @@ spec:
                                       required:
                                         - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     resourceFieldRef:
                                       properties:
                                         containerName:
@@ -12593,6 +13092,7 @@ spec:
                                       required:
                                         - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     secretKeyRef:
                                       properties:
                                         key:
@@ -12604,6 +13104,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                               required:
                                 - name
@@ -12619,6 +13120,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 prefix:
                                   type: string
                                 secretRef:
@@ -12628,6 +13130,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             type: array
                           image:
@@ -12829,8 +13332,8 @@ spec:
                                 name:
                                   type: string
                                 protocol:
-                                  type: string
                                   default: TCP
+                                  type: string
                               required:
                                 - containerPort
                               type: object
@@ -12917,6 +13420,18 @@ spec:
                             type: object
                           resources:
                             properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
                               limits:
                                 additionalProperties:
                                   anyOf:
@@ -13162,6 +13677,8 @@ spec:
                       type: boolean
                     hostPID:
                       type: boolean
+                    hostUsers:
+                      type: boolean
                     hostname:
                       type: string
                     imagePullSecrets:
@@ -13170,6 +13687,7 @@ spec:
                           name:
                             type: string
                         type: object
+                        x-kubernetes-map-type: atomic
                       type: array
                     initContainers:
                       items:
@@ -13202,6 +13720,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     fieldRef:
                                       properties:
                                         apiVersion:
@@ -13211,6 +13730,7 @@ spec:
                                       required:
                                         - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     resourceFieldRef:
                                       properties:
                                         containerName:
@@ -13226,6 +13746,7 @@ spec:
                                       required:
                                         - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     secretKeyRef:
                                       properties:
                                         key:
@@ -13237,6 +13758,7 @@ spec:
                                       required:
                                         - key
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   type: object
                               required:
                                 - name
@@ -13252,6 +13774,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 prefix:
                                   type: string
                                 secretRef:
@@ -13261,6 +13784,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                             type: array
                           image:
@@ -13464,8 +13988,8 @@ spec:
                                 name:
                                   type: string
                                 protocol:
-                                  type: string
                                   default: TCP
+                                  type: string
                               required:
                                 - containerPort
                               type: object
@@ -13554,6 +14078,18 @@ spec:
                             type: object
                           resources:
                             properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
                               limits:
                                 additionalProperties:
                                   anyOf:
@@ -13758,6 +14294,10 @@ spec:
                           - name
                         type: object
                       type: array
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
                     logger:
                       properties:
                         mode:
@@ -13809,6 +14349,25 @@ spec:
                           - conditionType
                         type: object
                       type: array
+                    resourceClaims:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          source:
+                            properties:
+                              resourceClaimName:
+                                type: string
+                              resourceClaimTemplateName:
+                                type: string
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     restartPolicy:
                       type: string
                     runtimeClassName:
@@ -13824,6 +14383,18 @@ spec:
                       type: integer
                     schedulerName:
                       type: string
+                    schedulingGates:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     securityContext:
                       properties:
                         fsGroup:
@@ -13946,9 +14517,22 @@ spec:
                                   type: string
                                 type: object
                             type: object
+                            x-kubernetes-map-type: atomic
+                          matchLabelKeys:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
                           maxSkew:
                             format: int32
                             type: integer
+                          minDomains:
+                            format: int32
+                            type: integer
+                          nodeAffinityPolicy:
+                            type: string
+                          nodeTaintsPolicy:
+                            type: string
                           topologyKey:
                             type: string
                           whenUnsatisfiable:
@@ -14027,6 +14611,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               user:
                                 type: string
                             required:
@@ -14043,6 +14628,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               volumeID:
                                 type: string
                             required:
@@ -14073,6 +14659,7 @@ spec:
                               optional:
                                 type: boolean
                             type: object
+                            x-kubernetes-map-type: atomic
                           csi:
                             properties:
                               driver:
@@ -14084,6 +14671,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               readOnly:
                                 type: boolean
                               volumeAttributes:
@@ -14110,6 +14698,7 @@ spec:
                                       required:
                                         - fieldPath
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     mode:
                                       format: int32
                                       type: integer
@@ -14130,6 +14719,7 @@ spec:
                                       required:
                                         - resource
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                   required:
                                     - path
                                   type: object
@@ -14170,6 +14760,7 @@ spec:
                                           - kind
                                           - name
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       dataSourceRef:
                                         properties:
                                           apiGroup:
@@ -14178,12 +14769,26 @@ spec:
                                             type: string
                                           name:
                                             type: string
+                                          namespace:
+                                            type: string
                                         required:
                                           - kind
                                           - name
                                         type: object
                                       resources:
                                         properties:
+                                          claims:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
                                           limits:
                                             additionalProperties:
                                               anyOf:
@@ -14224,6 +14829,7 @@ spec:
                                               type: string
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       storageClassName:
                                         type: string
                                       volumeMode:
@@ -14270,6 +14876,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                             required:
                               - driver
                             type: object
@@ -14354,6 +14961,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               targetPortal:
                                 type: string
                             required:
@@ -14434,6 +15042,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     downwardAPI:
                                       properties:
                                         items:
@@ -14448,6 +15057,7 @@ spec:
                                                 required:
                                                   - fieldPath
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                               mode:
                                                 format: int32
                                                 type: integer
@@ -14468,6 +15078,7 @@ spec:
                                                 required:
                                                   - resource
                                                 type: object
+                                                x-kubernetes-map-type: atomic
                                             required:
                                               - path
                                             type: object
@@ -14495,6 +15106,7 @@ spec:
                                         optional:
                                           type: boolean
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     serviceAccountToken:
                                       properties:
                                         audience:
@@ -14549,6 +15161,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               user:
                                 type: string
                             required:
@@ -14570,6 +15183,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               sslEnabled:
                                 type: boolean
                               storageMode:
@@ -14621,6 +15235,7 @@ spec:
                                   name:
                                     type: string
                                 type: object
+                                x-kubernetes-map-type: atomic
                               volumeName:
                                 type: string
                               volumeNamespace:
@@ -14651,6 +15266,10 @@ spec:
               properties:
                 address:
                   properties:
+                    CACerts:
+                      type: string
+                    name:
+                      type: string
                     url:
                       type: string
                   type: object
@@ -14663,6 +15282,10 @@ spec:
                     properties:
                       address:
                         properties:
+                          CACerts:
+                            type: string
+                          name:
+                            type: string
                           url:
                             type: string
                         type: object
@@ -14805,9 +15428,3 @@ spec:
       storage: true
       subresources:
         status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/opendatahub/odh-manifests/model-mesh/odh-modelmesh-controller/crd/bases/serving.kserve.io_servingruntimes.yaml
+++ b/opendatahub/odh-manifests/model-mesh/odh-modelmesh-controller/crd/bases/serving.kserve.io_servingruntimes.yaml
@@ -1,10 +1,10 @@
-# Copied from https://github.com/kserve/kserve/blob/v0.11.0-rc0/config/crd/serving.kserve.io_servingruntimes.yaml
+# Copied from https://github.com/kserve/kserve/blob/v0.11.0/config/crd/serving.kserve.io_servingruntimes.yaml
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: servingruntimes.serving.kserve.io
 spec:
   group: serving.kserve.io
@@ -82,6 +82,7 @@ spec:
                                       type: object
                                     type: array
                                 type: object
+                                x-kubernetes-map-type: atomic
                               weight:
                                 format: int32
                                 type: integer
@@ -128,10 +129,12 @@ spec:
                                       type: object
                                     type: array
                                 type: object
+                                x-kubernetes-map-type: atomic
                               type: array
                           required:
                             - nodeSelectorTerms
                           type: object
+                          x-kubernetes-map-type: atomic
                       type: object
                     podAffinity:
                       properties:
@@ -163,6 +166,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -186,6 +190,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     items:
                                       type: string
@@ -229,6 +234,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                               namespaceSelector:
                                 properties:
                                   matchExpressions:
@@ -252,6 +258,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                               namespaces:
                                 items:
                                   type: string
@@ -293,6 +300,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
                                     properties:
                                       matchExpressions:
@@ -316,6 +324,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
                                     items:
                                       type: string
@@ -359,6 +368,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                               namespaceSelector:
                                 properties:
                                   matchExpressions:
@@ -382,6 +392,7 @@ spec:
                                       type: string
                                     type: object
                                 type: object
+                                x-kubernetes-map-type: atomic
                               namespaces:
                                 items:
                                   type: string
@@ -420,6 +431,7 @@ spec:
                                 required:
                                   - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               fieldRef:
                                 properties:
                                   apiVersion:
@@ -429,6 +441,7 @@ spec:
                                 required:
                                   - fieldPath
                                 type: object
+                                x-kubernetes-map-type: atomic
                               resourceFieldRef:
                                 properties:
                                   containerName:
@@ -444,6 +457,7 @@ spec:
                                 required:
                                   - resource
                                 type: object
+                                x-kubernetes-map-type: atomic
                               secretKeyRef:
                                 properties:
                                   key:
@@ -455,6 +469,7 @@ spec:
                                 required:
                                   - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                         required:
                           - name
@@ -500,6 +515,7 @@ spec:
                                   required:
                                     - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 fieldRef:
                                   properties:
                                     apiVersion:
@@ -509,6 +525,7 @@ spec:
                                   required:
                                     - fieldPath
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 resourceFieldRef:
                                   properties:
                                     containerName:
@@ -524,6 +541,7 @@ spec:
                                   required:
                                     - resource
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 secretKeyRef:
                                   properties:
                                     key:
@@ -535,6 +553,7 @@ spec:
                                   required:
                                     - key
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               type: object
                           required:
                             - name
@@ -550,6 +569,7 @@ spec:
                                 optional:
                                   type: boolean
                               type: object
+                              x-kubernetes-map-type: atomic
                             prefix:
                               type: string
                             secretRef:
@@ -559,6 +579,7 @@ spec:
                                 optional:
                                   type: boolean
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         type: array
                       image:
@@ -762,8 +783,8 @@ spec:
                             name:
                               type: string
                             protocol:
-                              type: string
                               default: TCP
+                              type: string
                           required:
                             - containerPort
                           type: object
@@ -852,6 +873,18 @@ spec:
                         type: object
                       resources:
                         properties:
+                          claims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
                           limits:
                             additionalProperties:
                               anyOf:
@@ -1070,6 +1103,7 @@ spec:
                       name:
                         type: string
                     type: object
+                    x-kubernetes-map-type: atomic
                   type: array
                 labels:
                   additionalProperties:
@@ -1185,6 +1219,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           user:
                             type: string
                         required:
@@ -1201,6 +1236,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           volumeID:
                             type: string
                         required:
@@ -1231,6 +1267,7 @@ spec:
                           optional:
                             type: boolean
                         type: object
+                        x-kubernetes-map-type: atomic
                       csi:
                         properties:
                           driver:
@@ -1242,6 +1279,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           readOnly:
                             type: boolean
                           volumeAttributes:
@@ -1268,6 +1306,7 @@ spec:
                                   required:
                                     - fieldPath
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 mode:
                                   format: int32
                                   type: integer
@@ -1288,6 +1327,7 @@ spec:
                                   required:
                                     - resource
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               required:
                                 - path
                               type: object
@@ -1328,6 +1368,7 @@ spec:
                                       - kind
                                       - name
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   dataSourceRef:
                                     properties:
                                       apiGroup:
@@ -1336,12 +1377,26 @@ spec:
                                         type: string
                                       name:
                                         type: string
+                                      namespace:
+                                        type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
                                     properties:
+                                      claims:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
                                       limits:
                                         additionalProperties:
                                           anyOf:
@@ -1382,6 +1437,7 @@ spec:
                                           type: string
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   storageClassName:
                                     type: string
                                   volumeMode:
@@ -1428,6 +1484,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                         required:
                           - driver
                         type: object
@@ -1512,6 +1569,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           targetPortal:
                             type: string
                         required:
@@ -1592,6 +1650,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 downwardAPI:
                                   properties:
                                     items:
@@ -1606,6 +1665,7 @@ spec:
                                             required:
                                               - fieldPath
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           mode:
                                             format: int32
                                             type: integer
@@ -1626,6 +1686,7 @@ spec:
                                             required:
                                               - resource
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                         required:
                                           - path
                                         type: object
@@ -1653,6 +1714,7 @@ spec:
                                     optional:
                                       type: boolean
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 serviceAccountToken:
                                   properties:
                                     audience:
@@ -1707,6 +1769,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           user:
                             type: string
                         required:
@@ -1728,6 +1791,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           sslEnabled:
                             type: boolean
                           storageMode:
@@ -1779,6 +1843,7 @@ spec:
                               name:
                                 type: string
                             type: object
+                            x-kubernetes-map-type: atomic
                           volumeName:
                             type: string
                           volumeNamespace:
@@ -1810,9 +1875,3 @@ spec:
       served: true
       storage: true
       subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
#### Motivation
Update modelmesh-serving manifests in the `opendatahub/odh-manifests` directory to sync with the manifest changes in `config/` resulting from the commits included in [this sync](https://github.com/opendatahub-io/modelmesh-serving/pull/174)

#### Modifications
- Copied over the new 0.11.0 manifests over to `opendatahub/odh-manifests/model-mesh/odh-modelmesh-controller` 

#### Result
CRD version on the `main` branch is updated to 0.11.0

#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [x] Unit tests pass locally
- [ ] FVT tests pass locally
- [x] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [x] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 

#### Testing Instructions 
- Check out the PR from github and use the opendatahub quickstarts to deploy modelmesh serving using the manifests in `opendatahub/odh-manifests/model-mesh`. Ensure Model Serving functionality works as intended 
