### PR TITLE
update template manifests for fast/stable

### DIFF
--- a/opendatahub/odh-manifests/model-mesh/base/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh/base/kustomization.yaml
@@ -4,8 +4,6 @@ resources:
   - ../odh-modelmesh-controller/overlays/odh
   - ../odh-model-controller/overlays/odh
 
-commonLabels:
-  app.kubernetes.io/part-of: model-mesh
 namespace: opendatahub
 configMapGenerator:
   - envs:

--- a/opendatahub/odh-manifests/model-mesh/odh-model-controller/overlays/odh/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh/odh-model-controller/overlays/odh/kustomization.yaml
@@ -5,8 +5,6 @@ resources:
 
 patchesStrategicMerge:
   - odh_model_controller_manager_patch.yaml
-commonLabels:
-  app.kubernetes.io/managed-by: odh-model-controller
 
 configurations:
   - params.yaml

--- a/opendatahub/odh-manifests/model-mesh_stable/base/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_stable/base/kustomization.yaml
@@ -4,8 +4,6 @@ resources:
   - ../odh-modelmesh-controller/overlays/odh
   - ../odh-model-controller/overlays/odh
 
-commonLabels:
-  app.kubernetes.io/part-of: model-mesh
 namespace: opendatahub
 configMapGenerator:
   - envs:

--- a/opendatahub/odh-manifests/model-mesh_stable/odh-model-controller/overlays/odh/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_stable/odh-model-controller/overlays/odh/kustomization.yaml
@@ -5,8 +5,6 @@ resources:
 
 patchesStrategicMerge:
   - odh_model_controller_manager_patch.yaml
-commonLabels:
-  app.kubernetes.io/managed-by: odh-model-controller
 
 configurations:
   - params.yaml

--- a/opendatahub/odh-manifests/model-mesh_templates/base/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates/base/kustomization.yaml
@@ -4,8 +4,6 @@ resources:
   - ../odh-modelmesh-controller/overlays/odh
   - ../odh-model-controller/overlays/odh
 
-commonLabels:
-  app.kubernetes.io/part-of: model-mesh
 namespace: opendatahub
 configMapGenerator:
   - envs:

--- a/opendatahub/odh-manifests/model-mesh_templates/odh-model-controller/overlays/odh/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates/odh-model-controller/overlays/odh/kustomization.yaml
@@ -5,8 +5,6 @@ resources:
 
 patchesStrategicMerge:
   - odh_model_controller_manager_patch.yaml
-commonLabels:
-  app.kubernetes.io/managed-by: odh-model-controller
 
 configurations:
   - params.yaml

--- a/opendatahub/odh-manifests/model-mesh_templates/odh-model-controller/overlays/odh/odh_model_controller_manager_patch.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates/odh-model-controller/overlays/odh/odh_model_controller_manager_patch.yaml
@@ -11,6 +11,11 @@ spec:
             - --leader-elect
             - "--monitoring-namespace"
             - "$(MONITORING_NS)"
+            #This is hardcoded to be false in the overlay to model-mesh.
+            # Once Kserve and Modelmesh CRD conflict is resolved and both components can be installed together,
+            # ODH Model Controller will not be deployed as a overlay anymore and will be deployed only as an independent component.
+            # When that happens, the "kserve-enabled" flag needs to be removed
+            - --kserve-enabled=false
           image: $(odh-model-controller)
           env:
             - name: MONITORING_NS

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/base/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/base/kustomization.yaml
@@ -4,8 +4,6 @@ resources:
   - ../odh-modelmesh-controller/overlays/odh
   - ../odh-model-controller/overlays/odh
 
-commonLabels:
-  app.kubernetes.io/part-of: model-mesh
 namespace: opendatahub
 configMapGenerator:
   - envs:

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-model-controller/overlays/odh/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-model-controller/overlays/odh/kustomization.yaml
@@ -5,8 +5,6 @@ resources:
 
 patchesStrategicMerge:
   - odh_model_controller_manager_patch.yaml
-commonLabels:
-  app.kubernetes.io/managed-by: odh-model-controller
 
 configurations:
   - params.yaml

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-model-controller/overlays/odh/odh_model_controller_manager_patch.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-model-controller/overlays/odh/odh_model_controller_manager_patch.yaml
@@ -11,6 +11,10 @@ spec:
             - --leader-elect
             - "--monitoring-namespace"
             - "$(MONITORING_NS)"
+            #This is hardcoded to be false in the overlay to model-mesh.
+            # Once Kserve and Modelmesh CRD conflict is resolved and both components can be installed together,
+            # ODH Model Controller will not be deployed as a overlay anymore and will be deployed only as an independent component.
+            # When that happens, the "kserve-enabled" flag needs to be removed            
           image: $(odh-model-controller)
           env:
             - name: MONITORING_NS

--- a/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/kustomization.yaml
+++ b/opendatahub/odh-manifests/model-mesh_templates_stable/odh-modelmesh-controller/overlays/odh/kustomization.yaml
@@ -8,8 +8,5 @@ resources:
   - ./rbac/
   - ./manager
 
-commonLabels:
-  app.kubernetes.io/managed-by: modelmesh-controller
-
 configurations:
   - params.yaml


### PR DESCRIPTION
#### Motivation
Regression issue: 
- https://github.com/opendatahub-io/modelmesh-serving/pull/138
- https://github.com/opendatahub-io/modelmesh-serving/pull/115

It was because the template folder was not updated properly so this pr updated manifests template folder.

#### Test 
It is not needed to test because it does not change sources. 

#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [X] Unit tests pass locally
- [X] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
