### PR TITLE
move manifests to config/

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -1,0 +1,67 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../overlays/odh
+  - ../default
+  - ../prometheus
+
+commonLabels:
+  app.kubernetes.io/part-of: model-mesh
+namespace: opendatahub
+configMapGenerator:
+  - envs:
+      - params.env
+    name: mesh-parameters
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+  - fieldref:
+      fieldPath: metadata.namespace
+    name: mesh-namespace
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: mesh-parameters
+  - fieldref:
+      fieldPath: data.monitoring-namespace
+    name: monitoring-namespace
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: mesh-parameters
+  - fieldref:
+      fieldPath: data.odh-modelmesh
+    name: odh-modelmesh
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: mesh-parameters
+  - fieldref:
+      fieldPath: data.odh-mm-rest-proxy
+    name: odh-mm-rest-proxy
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: mesh-parameters
+  - fieldref:
+      fieldPath: data.odh-modelmesh-runtime-adapter
+    name: odh-modelmesh-runtime-adapter
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: mesh-parameters
+  - fieldref:
+      fieldPath: data.odh-modelmesh-controller
+    name: odh-modelmesh-controller
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: mesh-parameters
+  - fieldref:
+      fieldPath: data.odh-openvino
+    name: odh-openvino
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: mesh-parameters

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,0 +1,6 @@
+monitoring-namespace=opendatahub
+odh-mm-rest-proxy=quay.io/opendatahub/rest-proxy:fast
+odh-modelmesh-runtime-adapter=quay.io/opendatahub/modelmesh-runtime-adapter:fast
+odh-modelmesh=quay.io/opendatahub/modelmesh:fast
+odh-openvino=quay.io/opendatahub/openvino_model_server:2022.3-release
+odh-modelmesh-controller=quay.io/opendatahub/modelmesh-controller:fast

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./scripts/
+  - ./quickstart.yaml
+  - ./rbac/
+  - ./manager
+
+commonLabels:
+  app.kubernetes.io/managed-by: modelmesh-controller
+
+configurations:
+  - params.yaml

--- a/config/overlays/odh/manager/kustomization.yaml
+++ b/config/overlays/odh/manager/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./service.yaml

--- a/config/overlays/odh/manager/service.yaml
+++ b/config/overlays/odh/manager/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: modelmesh-controller
+  name: modelmesh-controller
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+  selector:
+    control-plane: modelmesh-controller

--- a/config/overlays/odh/params.yaml
+++ b/config/overlays/odh/params.yaml
@@ -1,0 +1,15 @@
+varReference:
+  - path: metadata/namespace
+    kind: ServiceAccount
+    apiVersion: v1
+  - path: metadata/name
+    kind: ClusterRoleBinding
+    apiGroup: rbac.authorization.k8s.io
+  - path: subjects/namespace
+    kind: RoleBinding
+    apiGroup: rbac.authorization.k8s.io
+  - path: spec/template/spec/containers[]/image
+    kind: Deployment
+    apiVersion: apps/v1
+  - path: data
+    kind: ConfigMap

--- a/config/overlays/odh/quickstart.yaml
+++ b/config/overlays/odh/quickstart.yaml
@@ -1,0 +1,173 @@
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd
+  labels:
+    component: model-mesh-etcd
+spec:
+  ports:
+    - name: etcd-client-port
+      port: 2379
+      protocol: TCP
+      targetPort: 2379
+  selector:
+    component: model-mesh-etcd
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: model-mesh-etcd
+  name: etcd
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: model-mesh-etcd
+  template:
+    metadata:
+      labels:
+        component: model-mesh-etcd
+    spec:
+      volumes:
+        - name: scripts
+          configMap:
+            name: etcd-scripts
+            defaultMode: 0554
+      initContainers:
+        - name: etcd-secret-creator
+          image: registry.redhat.io/openshift4/ose-cli@sha256:25fef269ac6e7491cb8340119a9b473acbeb53bc6970ad029fdaae59c3d0ca61
+          command: ["/bin/bash", "-c", "--"]
+          args:
+            - |
+              etcdpasswordexists=$(oc get secrets -o name | grep etcd-passwords || echo "false")
+              modelservingetcdexists=$(oc get secrets -o name | grep model-serving-etcd || echo "false")
+
+              if [[ $etcdpasswordexists == "false" && $modelservingetcdexists == "false" ]]; then
+                echo "creating etcdpasswords and model-serving-etcd secrets"
+                ETC_ROOT_PSW=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 32 | head -n 1)
+                oc create secret generic etcd-passwords --type=string --from-literal=root=$ETC_ROOT_PSW
+                oc create secret generic model-serving-etcd --type=string --from-literal=etcd_connection="{\"endpoints\": \"http://etcd:2379\",\"root_prefix\": \"modelmesh-serving\",\"userid\": \"root\",\"password\": \"$ETC_ROOT_PSW\"}"
+                exit 0
+              elif [[ $etcdpasswordexists != "false" && $modelservingetcdexists == "false" ]]; then
+                echo "etcdpasswords exists, creating model-serving-etcd secret"
+                ETC_ROOT_PSW=$(oc get secrets/etcd-passwords --template={{.data.root}} | base64 -d)
+                oc create secret generic model-serving-etcd --type=string --from-literal=etcd_connection="{\"endpoints\": \"http://etcd:2379\",\"root_prefix\": \"modelmesh-serving\",\"userid\": \"root\",\"password\": \"$ETC_ROOT_PSW\"}"
+                exit 0
+              elif [[ $etcdpasswordexists == "false" && $modelservingetcdexists != "false" ]]; then
+                echo "model-serving-etcd exists, creating etcdpasswords secret"
+                ETC_ROOT_PSW=$(oc get secrets/model-serving-etcd --template={{.data.etcd_connection}} | base64 -d | grep -o '"password": *"[^"]*"' | grep -o '"[^"]*"$' | grep -oP '"\K[^"\047]+(?=["\047])') 
+                oc create secret generic etcd-passwords --type=string --from-literal=root=$ETC_ROOT_PSW
+                exit 0
+              else 
+                echo "secrets etcdpasswords and model-serving-etcd exist, doing nothing"
+                exit 0
+              fi
+      containers:
+        - command:
+            - etcd
+            - --listen-client-urls
+            - http://0.0.0.0:2379
+            - --advertise-client-urls
+            - http://0.0.0.0:2379
+            - "--data-dir"
+            - /tmp/etcd.data
+          image: registry.redhat.io/rhel7/etcd@sha256:d3495b263b103681f1b09a558be43c21989bfc269eb90f84c2609042cebdc626
+          name: etcd
+          env:
+            - name: ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: etcd-passwords
+                  key: root
+          volumeMounts:
+            - mountPath: /home/scripts
+              name: scripts
+          ports:
+            - containerPort: 2379
+              name: client
+              protocol: TCP
+            - containerPort: 2380
+              name: server
+              protocol: TCP
+          resources: # ref: https://github.com/coreos/etcd-operator/blob/master/doc/user/spec_examples.md#three-member-cluster-with-resource-requirement
+            limits:
+              cpu: 300m
+              memory: 200Mi
+            requests:
+              cpu: 200m
+              memory: 100Mi
+          livenessProbe:
+            tcpSocket:
+              port: 2379
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 2379
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - /home/scripts/enable_auth.sh ${ROOT_PASSWORD}
+      serviceAccountName: etcd-serviceaccount
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-serviceaccount
+  namespace: $(mesh-namespace)
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-role
+subjects:
+  - kind: ServiceAccount
+    name: etcd-serviceaccount
+    namespace: $(mesh-namespace)

--- a/config/overlays/odh/rbac/kustomization.yaml
+++ b/config/overlays/odh/rbac/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../rbac/cluster-scope
+  - ./networkpolicy_etcd.yaml
+  - ./role_apps_metrics_access.yaml
+  - ./user_cluster_roles.yaml
+
+patchesStrategicMerge:
+  - remove_networkpolicy_rumtime_patch.yaml

--- a/config/overlays/odh/rbac/networkpolicy_etcd.yaml
+++ b/config/overlays/odh/rbac/networkpolicy_etcd.yaml
@@ -1,0 +1,36 @@
+# Copyright 2022 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: etcd
+spec:
+  podSelector:
+    matchLabels:
+      component: model-mesh-etcd
+      app.kubernetes.io/part-of: model-mesh
+  ingress:
+    # etcd communication
+    - from:
+        - namespaceSelector:
+            # matches controller and runtime pods
+            matchLabels:
+              modelmesh-enabled: "true"
+          # mataches internal pods
+        - podSelector: {}
+      ports:
+        - port: 2379
+          protocol: TCP
+  policyTypes:
+    - Ingress

--- a/config/overlays/odh/rbac/remove_networkpolicy_rumtime_patch.yaml
+++ b/config/overlays/odh/rbac/remove_networkpolicy_rumtime_patch.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: modelmesh-runtimes

--- a/config/overlays/odh/rbac/role_apps_metrics_access.yaml
+++ b/config/overlays/odh/rbac/role_apps_metrics_access.yaml
@@ -1,0 +1,41 @@
+# Deploying a RoleBinding in a given Namespace
+# that gives the Prometheus SA the following role
+# will allow that Prometheus to scrape Services
+# in that RoleBinding's Namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-ns-access
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get

--- a/config/overlays/odh/rbac/user_cluster_roles.yaml
+++ b/config/overlays/odh/rbac/user_cluster_roles.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: model-serving-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-model-serving-admin: "true"
+rules: []
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: model-serving-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-model-serving-admin: "true"
+rules:
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - inferenceservices
+      - servingruntimes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: model-serving-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - servingruntimes
+      - servingruntimes/status
+      - servingruntimes/finalizers
+      - inferenceservices
+      - inferenceservices/status
+      - inferenceservices/finalizers
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/overlays/odh/scripts/enable_auth.sh
+++ b/config/overlays/odh/scripts/enable_auth.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e -o pipefail
+export ETCDCTL_API=3
+
+function etcd::availability() {
+    local cmd=$1 # Command whose output we require
+    local interval=$2 # How many seconds to sleep between tries
+    local iterations=$3 # How many times we attempt to run the command
+
+    ii=0
+
+    while [ $ii -le $iterations ]
+    do
+
+        token=$($cmd) && returncode=$? || returncode=$?
+        if [ $returncode -eq 0 ]; then
+            break
+        fi
+
+        ((ii=ii+1))
+        if [ $ii -eq 100 ]; then
+            echo $cmd "did not return a value"
+            exit 1
+        fi
+        sleep $interval
+    done
+    echo $token
+}
+
+cmd='etcdctl --endpoints=http://0.0.0.0:2379 endpoint health'
+
+etcd::availability "${cmd}" 6 10
+
+PASSWORD="${1:-password}"
+
+echo $PASSWORD | etcdctl --endpoints=http://0.0.0.0:2379 user add root --interactive=false
+etcdctl --endpoints=http://0.0.0.0:2379 auth enable

--- a/config/overlays/odh/scripts/kustomization.yaml
+++ b/config/overlays/odh/scripts/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: etcd-scripts
+    files:
+      - enable_auth.sh


### PR DESCRIPTION
#### Motivation
- manifests readiness for Operator v2 such that the operator can get the manifests from each component repo directly, eliminating the need to have `odh-manifests`

#### Modifications
- put all the latest manifests for modelmesh from `/opendatahub/odh-manifests` and copied them over to `/config` with the appropriate changes to make all the params and overlays work. 

#### Result
modelmesh-serving manifests can now be directly pulled by the operator from this repo itself, using the `/config` directory as the manifest source.

#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
