### PR TITLE
auto add issues to main odh board

### DIFF
--- a/.github/workflows/auto-add-issues-to-project.yaml
+++ b/.github/workflows/auto-add-issues-to-project.yaml
@@ -1,0 +1,24 @@
+name: Auto Add Issues to Tracking boards
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add-to-project:
+    name: Add issue to projects
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate github-app token
+        id: app-token
+        uses: getsentry/action-github-app-token@v2
+        with:
+          app_id: ${{ secrets.DEVOPS_APP_ID }}
+          private_key: ${{ secrets.DEVOPS_APP_PRIVATE_KEY }}
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/opendatahub-io/projects/40
+          github-token: ${{ steps.app-token.outputs.token }}
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/opendatahub-io/projects/45
+          github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
#### Motivation
This will enable auto adding of all our issues to main ODH board. This will help QE and docs to track all issues going into ODH and RHODS releases.

#### Modifications
No code modifications

#### Result


#### PR checklist
No need to check the tests, as it is not a code change but a GH action change.
Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
