### PR TITLE
Apply patch to remove empty string of caBundle

### DIFF
--- a/config/overlays/odh/default/kustomization.yaml
+++ b/config/overlays/odh/default/kustomization.yaml
@@ -19,3 +19,12 @@ transformers:
 
 configurations:
   - params.yaml
+
+patches:
+  # Since OpenShift serving-certificates are being used,
+  # remove CA bundle placeholders
+  - patch: |-
+      - op: remove
+        path: "/webhooks/0/clientConfig/caBundle"
+    target:
+      kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
#### Motivation
This change is to fix https://issues.redhat.com/browse/RHOAIENG-244. 

#### Modifications
Empty string of caBundle in `ValidationWebhookConfiguration` causes cyclic calling of reconcilation for DataScienceCluster controller. With this PR I had removed the empty caBundle string from `ValidationWebhookConfiguration`. Similiar [patch](https://github.com/opendatahub-io/kserve/blob/bb3615b964ed93e715769ee981ffa228ac3a0227/config/default/kustomization.yaml#L225) is already applied in KServe manifest but missing in ModelMesh-Serving.

#### Result
It should not impact any existing functionalities.

#### Testing Instruction
1. Clone the code changes
2. navigate to `modelmesh-serving` folder
3. create manifest
```
kustomize build config/overlays/odh > mm.yaml
```
4. Varify caBundle field should not present in ValidatingWebhookConfiguration resource.

#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
