### PR TITLE
Cherry-pick: Apply patch to remove empty string of caBundle #262

### DIFF
--- a/config/overlays/odh/default/kustomization.yaml
+++ b/config/overlays/odh/default/kustomization.yaml
@@ -19,3 +19,12 @@ transformers:
 
 configurations:
   - params.yaml
+
+patches:
+  # Since OpenShift serving-certificates are being used,
+  # remove CA bundle placeholders
+  - patch: |-
+      - op: remove
+        path: "/webhooks/0/clientConfig/caBundle"
+    target:
+      kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
#### Motivation

Cherry-pick https://github.com/opendatahub-io/modelmesh-serving/pull/262
#### Modifications

#### Result


#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
