### PR TITLE
pin envtest version, not using go 1.22 yet

### DIFF
--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -114,7 +114,7 @@ RUN true \
 
 # Use setup-envtest for kubebuilder to use K8s version 1.23+ for autoscaling/v2 (HPA)
 RUN true \
-    && go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest \
+    && go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240320141353-395cfc7486e6 \
     && setup-envtest use 1.23 \
     && true
 

--- a/Dockerfile.develop.ci
+++ b/Dockerfile.develop.ci
@@ -113,7 +113,7 @@ RUN true \
 
 # Use setup-envtest for kubebuilder to use K8s version 1.23+ for autoscaling/v2 (HPA)
 RUN true \
-    && go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest \
+    && go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240320141353-395cfc7486e6 \
     && setup-envtest use 1.23 \
     && true
 


### PR DESCRIPTION
#### Motivation

fix(test): pins k8s env test to concrete version
Latest one requires go1.22 which is not the version used by prow jobs atm.

