### PR TITLE
Use a more fine-grained RBAC check in oauth-proxy

### DIFF
--- a/config/internal/base/deployment.yaml.tmpl
+++ b/config/internal/base/deployment.yaml.tmpl
@@ -133,8 +133,8 @@ spec:
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key
             - --cookie-secret=SECRET
-            - '--openshift-delegate-urls={"/": {"namespace": "{{.AuthNamespace}}", "resource": "services", "verb": "get"}}'
-            - '--openshift-sar={"namespace": "{{.AuthNamespace}}", "resource": "services", "verb": "get"}'
+            - '--openshift-delegate-urls={"/": {"namespace": "{{.AuthNamespace}}", "group": "serving.kserve.io", "resource": "servingruntimes", "verb": "get", "name": "{{.Name}}"}}'
+            - '--openshift-sar={"namespace": "{{.AuthNamespace}}", "group": "serving.kserve.io", "resource": "servingruntimes", "verb": "get", "name": "{{.Name}}"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
           image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
           ports:


### PR DESCRIPTION
#### Motivation

ServingRuntimes on a namespace need to be protected individually, rather than allowing/rejecting access to all deployed runtimes in a namespace in conjunction.

#### Modifications

In oauth-proxy, instead of checking for GET over Kubernetes Services, do a more fine-grained check over ServingRuntimes: test that the user can GET the ServingRuntime associated with the deployment. This will allow protecting ServingRuntimes individually.

#### Result

The oauth-proxy will now allow access only if the provided token has GET privileges over a specific ServingRuntime.

#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
