### PR TITLE
[RHOAIENG-11043] - Konflux Build failure for modelmesh-serving component

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,13 @@ COPY controllers/ controllers/
 COPY generated/ generated/
 COPY pkg/ pkg/
 COPY version /etc/modelmesh-version
+# Copy the go.mod and sum and download dependencies
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
 
 # Build using native go compiler from BUILDPLATFORM but compiled output for TARGETPLATFORM
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg \
-    GOOS=${TARGETOS:-linux} \
+RUN GOOS=${TARGETOS:-linux} \
     GOARCH=${TARGETARCH:-amd64} \
     CGO_ENABLED=0 \
     GO111MODULE=on \


### PR DESCRIPTION
chore:	Add the go.mod and go.sum files to the builder image, on Konflux the
	dependencies were not getting resolved due to the lack of these files.

#### Motivation

#### Modifications

#### Result


#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
