### PR TITLE
[RHOAIENG-11850] Updated etcd manifest

### DIFF
--- a/config/overlays/odh/quickstart.yaml
+++ b/config/overlays/odh/quickstart.yaml
@@ -76,6 +76,13 @@ spec:
                 echo "secrets etcdpasswords and model-serving-etcd exist, doing nothing"
                 exit 0
               fi
+          resources:
+            limits:
+              cpu: 10m
+              memory: 40Mi
+            requests:
+              cpu: 5m
+              memory: 20Mi
       containers:
         - command:
             - etcd


### PR DESCRIPTION
Updated the manifest to include requests and limits for the etcd deployment. 

Tested by applying resource quota to the redhat-ods-applications project and viewing which resources did not automatically rollout after applying the rq. 
After finding that the etcd deployment was the only pod that was not automatically redeployed, viewed the metrics for the etcd pod with no changes to find the request boundaries, and then added and deleted multiple ISVC's to find the limit boundaries. 

### Instructions to apply ResourceQuota:

Here is a copy of the RQ I used:
```
apiVersion: v1
kind: ResourceQuota
metadata:
  name: compute-resources
spec:
  hard:
    pods: "4" 
    requests.cpu: 50m 
    requests.memory: 96Mi 
    limits.cpu: "1" 
    limits.memory: 512Mi 
``` 
2 ways to apply -- CLI or UI

1. **Using the CL**I, ensure you are logged into the cluster, and using the intended project you want to apply the RQ to (in this case we are applying to the **redhat-ods-applications** project/namespace.
      a. in the directory where you have saved the above RQ yaml, run `oc apply -f <nameOfResourceQuota.yaml>`

2. **Using the UI**, there are 2 ways -- Creating a Pod or a ResourceQuota directly

**Creating a Pod to create a ResourceQuota:**
      a. In the sidebar, navigate to Workloads, and then Pods.
      b. Ensure you are in the project you want the RQ applied to. There is a drop-down list at the top left of the screen.                  In this case we are using the redhat-ods-applications project
      c. Click the blue "Create Pod" button at the top right of the page, and paste the RQ yaml defined above.
      d. Click the blue "Create" button at the bottom.  -- View the ResourceQuota by navigating to the sidebar again,             clicking Administration > and then Workloads.

**Creating a ResourceQuota Directly:**
      a. In the sidebar, navigate to Administration > and then ResourceQuotas.
      b. Ensure you are in the project you want the RQ applied to. There is a drop-down list at the top left of the screen.                  In this case we are using the redhat-ods-applications project
      c. Click the blue "Create ResourceQuota" button at the top right of the page, and paste the RQ yaml defined above -- or you can manually edit the values you want for the RQ.
      d. Click the blue "Create" button at the bottom. 

Once the RQ is applied, modify the request and limit values to satisfy the resources in your project. The deployments that are not automatically redeployed are the deployments that do not have resource values defined.  
     
#### Motivation

#### Modifications

#### Result


#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
