### PR TITLE
RHOAIENG-11850: Cherry-pick fix to release-0.12.0-rc0

### DIFF
--- a/config/overlays/odh/quickstart.yaml
+++ b/config/overlays/odh/quickstart.yaml
@@ -76,6 +76,13 @@ spec:
                 echo "secrets etcdpasswords and model-serving-etcd exist, doing nothing"
                 exit 0
               fi
+          resources:
+            limits:
+              cpu: 10m
+              memory: 40Mi
+            requests:
+              cpu: 5m
+              memory: 20Mi
       containers:
         - command:
             - etcd


### PR DESCRIPTION
#### Motivation

#### Modifications

#### Result

Cherry picked the fixes from https://github.com/opendatahub-io/modelmesh-serving/pull/303  to the release branch 0.12.0-rc0


#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
