### PR TITLE
[RHOAIENG-13816] Updated etcd manifest

### DIFF
--- a/config/overlays/odh/quickstart.yaml
+++ b/config/overlays/odh/quickstart.yaml
@@ -78,11 +78,11 @@ spec:
               fi
           resources:
             limits:
-              cpu: 10m
-              memory: 40Mi
+              cpu: 500m
+              memory: 400Mi
             requests:
-              cpu: 5m
-              memory: 20Mi
+              cpu: 250m
+              memory: 200Mi
       containers:
         - command:
             - etcd


### PR DESCRIPTION
#### Motivation
Previous resources in https://github.com/opendatahub-io/modelmesh-serving/pull/303 was too low and caused modelmesh deployments to fail. -- this pr made limit and request values higher in the etcd container.

#### Modifications

#### Result


#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
