### PR TITLE
Add release metadata for MM

### DIFF
--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -1,0 +1,4 @@
+releases:
+  - name: ModelMesh Serving
+    version: v0.12.0
+    repoUrl: https://github.com/kserve/modelmesh-serving


### PR DESCRIPTION
#### Motivation
Closes: https://issues.redhat.com/browse/RHOAIENG-18612
Adding release metadata for modelmesh-serving that will be displayed in Dashboard

#### Modifications

#### Result


#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
