### PR TITLE
[RHOAIENG-18240] - Update ETCD in ModelMesh

### DIFF
--- a/config/dependencies/fvt.yaml
+++ b/config/dependencies/fvt.yaml
@@ -53,7 +53,7 @@ spec:
             - /tmp/etcd.data
           # image: quay.io/coreos/etcd:v3.5.4
           # Tag -> registry.access.redhat.com/rhel7/etcd:3.2.32-34
-          image: registry.redhat.io/rhel7/etcd@sha256:d3495b263b103681f1b09a558be43c21989bfc269eb90f84c2609042cebdc626
+          image: registry.redhat.io/openshift4/ose-etcd@sha256:d3275cd886d13865937d225d8138db7f6b7bf59ac1a94d9fbe61e35286bee6ff
           name: etcd
           ports:
             - containerPort: 2379

--- a/config/overlays/odh/quickstart.yaml
+++ b/config/overlays/odh/quickstart.yaml
@@ -49,7 +49,7 @@ spec:
             defaultMode: 0554
       initContainers:
         - name: etcd-secret-creator
-          image: registry.redhat.io/openshift4/ose-cli@sha256:25fef269ac6e7491cb8340119a9b473acbeb53bc6970ad029fdaae59c3d0ca61
+          image: registry.redhat.io/openshift4/ose-cli@sha256:4cfb4219f46c8cc25a5e567fd4cb8babe9a3778b0b86a1e354a3403994ef3677
           command: ["/bin/bash", "-c", "--"]
           args:
             - |
@@ -92,7 +92,7 @@ spec:
             - http://0.0.0.0:2379
             - "--data-dir"
             - /tmp/etcd.data
-          image: registry.redhat.io/rhel7/etcd@sha256:d3495b263b103681f1b09a558be43c21989bfc269eb90f84c2609042cebdc626
+          image: registry.redhat.io/openshift4/ose-etcd@sha256:d3275cd886d13865937d225d8138db7f6b7bf59ac1a94d9fbe61e35286bee6ff
           name: etcd
           env:
             - name: ROOT_PASSWORD

--- a/opendatahub/scripts/manifests/fvt/fvt.yaml
+++ b/opendatahub/scripts/manifests/fvt/fvt.yaml
@@ -53,7 +53,7 @@ spec:
             - /tmp/etcd.data
           # image: quay.io/coreos/etcd:v3.5.4
           # Tag -> registry.access.redhat.com/rhel7/etcd:3.2.32-34
-          image: registry.redhat.io/rhel7/etcd@sha256:d3495b263b103681f1b09a558be43c21989bfc269eb90f84c2609042cebdc626
+          image: registry.redhat.io/openshift4/ose-etcd@sha256:d3275cd886d13865937d225d8138db7f6b7bf59ac1a94d9fbe61e35286bee6ff
           name: etcd
           ports:
             - containerPort: 2379


### PR DESCRIPTION
chore:	Update etcd and ose-cli images

#### Motivation

#### Modifications
etcd image updated:

Tested with:
```yaml
spec:
  components:
    codeflare:
      managementState: Removed
    dashboard:
      managementState: Removed
    datasciencepipelines:
      managementState: Removed
    kserve:
      managementState: Removed
      serving:
        ingressGateway:
          certificate:
            type: OpenshiftDefaultIngress
        managementState: Managed
        name: knative-serving
    kueue:
      managementState: Removed
    modelmeshserving:
      managementState: Managed
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: overlays/odh
            uri: "https://github.com/spolti/modelmesh-serving/tarball/model-mesh"
    modelregistry:
      managementState: Removed
      registriesNamespace: rhoai-model-registries
    ray:
      managementState: Removed
    trainingoperator:
      managementState: Removed
    trustyai:
      managementState: Removed
    workbenches:
      managementState: Removed
```

Deploy any model using modelmesh.

#### Result
<img width="1055" alt="Screenshot 2025-02-11 at 16 52 28" src="https://github.com/user-attachments/assets/2162fd08-f7d1-405a-9943-864bb60086c7" />


#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
