### PR TITLE
[Cherry-pick] Update the oauth-proxy to the latest (#315)

### DIFF
--- a/config/internal/base/deployment.yaml.tmpl
+++ b/config/internal/base/deployment.yaml.tmpl
@@ -136,7 +136,7 @@ spec:
             - '--openshift-delegate-urls={"/": {"namespace": "{{.AuthNamespace}}", "resource": "services", "verb": "get"}}'
             - '--openshift-sar={"namespace": "{{.AuthNamespace}}", "resource": "services", "verb": "get"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-          image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
+          image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
           ports:
             - containerPort: 8443
               name: https

--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -103,7 +103,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -415,7 +415,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -697,7 +697,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1053,7 +1053,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1358,7 +1358,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1655,7 +1655,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1957,7 +1957,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -2253,7 +2253,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
chore:	Update the oauth-proxy to the latest
	registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf


Cherry-picks: https://github.com/opendatahub-io/modelmesh-serving/pull/315
#### Motivation

#### Modifications

#### Result


#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
