### PR TITLE
fix(kustomize): ensures compatibility with v5

### DIFF
--- a/config/overlays/odh/default/kustomization.yaml
+++ b/config/overlays/odh/default/kustomization.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/config/overlays/odh/default/params.yaml
+++ b/config/overlays/odh/default/params.yaml
@@ -1,4 +1,3 @@
 varReference:
-  - path: spec/template/spec/containers[]/image
+  - path: spec/template/spec/containers/image
     kind: Deployment
-    apiVersion: apps/v1

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -1,65 +1,68 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
-  - ../../prometheus
-  - ./default
-  - ./scripts
-  - ./quickstart.yaml
-  - ./rbac
+- ../../prometheus
+- ./default
+- ./scripts
+- ./quickstart.yaml
+- ./rbac
 
 namespace: opendatahub
 configMapGenerator:
-  - envs:
-      - params.env
-    name: mesh-parameters
+- envs:
+  - params.env
+  name: mesh-parameters
 generatorOptions:
   disableNameSuffixHash: true
 
+patches:
+  - path: ./crd/clusterservingruntime_patch_delete.yaml
 
 vars:
-  - fieldref:
-      fieldPath: metadata.namespace
-    name: mesh-namespace
-    objref:
-      apiVersion: v1
-      kind: ConfigMap
-      name: mesh-parameters
-  - fieldref:
-      fieldPath: data.odh-modelmesh
-    name: odh-modelmesh
-    objref:
-      apiVersion: v1
-      kind: ConfigMap
-      name: mesh-parameters
-  - fieldref:
-      fieldPath: data.odh-mm-rest-proxy
-    name: odh-mm-rest-proxy
-    objref:
-      apiVersion: v1
-      kind: ConfigMap
-      name: mesh-parameters
-  - fieldref:
-      fieldPath: data.odh-modelmesh-runtime-adapter
-    name: odh-modelmesh-runtime-adapter
-    objref:
-      apiVersion: v1
-      kind: ConfigMap
-      name: mesh-parameters
-  - fieldref:
-      fieldPath: data.odh-modelmesh-controller
-    name: odh-modelmesh-controller
-    objref:
-      apiVersion: v1
-      kind: ConfigMap
-      name: mesh-parameters
+- fieldref:
+    fieldPath: metadata.namespace
+  name: mesh-namespace
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: mesh-parameters
+- fieldref:
+    fieldPath: data.odh-modelmesh
+  name: odh-modelmesh
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: mesh-parameters
+- fieldref:
+    fieldPath: data.odh-mm-rest-proxy
+  name: odh-mm-rest-proxy
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: mesh-parameters
+- fieldref:
+    fieldPath: data.odh-modelmesh-runtime-adapter
+  name: odh-modelmesh-runtime-adapter
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: mesh-parameters
+- fieldref:
+    fieldPath: data.odh-modelmesh-controller
+  name: odh-modelmesh-controller
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: mesh-parameters
 
-commonLabels:
-  app: model-mesh
-  app.kubernetes.io/part-of: model-mesh
 
-patchesStrategicMerge:
-  - ./crd/clusterservingruntime_patch_delete.yaml
 
 configurations:
-  - params.yaml
+- params.yaml
+
+labels:
+- includeSelectors: true
+  pairs:
+    app: model-mesh
+    app.kubernetes.io/part-of: model-mesh

--- a/config/overlays/odh/params.yaml
+++ b/config/overlays/odh/params.yaml
@@ -1,15 +1,11 @@
 varReference:
   - path: metadata/namespace
     kind: ServiceAccount
-    apiVersion: v1
   - path: metadata/name
     kind: ClusterRoleBinding
-    apiGroup: rbac.authorization.k8s.io
   - path: subjects/namespace
     kind: RoleBinding
-    apiGroup: rbac.authorization.k8s.io
   - path: spec/template/spec/containers[]/image
     kind: Deployment
-    apiVersion: apps/v1
   - path: data
     kind: ConfigMap


### PR DESCRIPTION
#### Motivation

Otherwise it's blocking https://github.com/opendatahub-io/opendatahub-operator/pull/2259

#### Modifications

Adjusted kustomize manifests to work with v5 (and so libraries in the aforementioned PR).

#### How to test

```sh
❯ git co HEAD~
❯ kustomize version
v5.7.1
❯ kustomize build config/overlays/odh
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
Error: accumulating resources: accumulation err='accumulating resources from './default': '/home/bartek/code/redhat/model-serving/modelmesh-serving/config/overlays/odh/default' must resolve to a file': recursed accumulation of path '/home/bartek/code/redhat/model-serving/modelmesh-serving/config/overlays/odh/default': error unmarshaling JSON: while decoding JSON: json: unknown field "apiVersion"

❯ mise use kustomize@4
mise ~/code/redhat/model-serving/modelmesh-serving/mise.toml tools: kustomize@4.5.7

❯ kustomize version
{Version:kustomize/v4.5.7 GitCommit:56d82a8378dfc8dc3b3b1085e5a6e67b82966bd7 BuildDate:2022-08-02T16:35:54Z GoOs:linux GoArch:amd64}

❯ kustomize build config/overlays/odh > old.yaml

❯ git co -
Previous HEAD position was cebfb51 Update Tekton output-image tags to version odh-v2.33 (#364)
❯ mise use kustomize@5
mise ~/code/redhat/model-serving/modelmesh-serving/mise.toml tools: kustomize@5.7.1

❯ kustomize version
v5.7.1

❯ kustomize build config/overlays/odh > new.yaml
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.

 ❯ diff old.yaml new.yaml
# SHOWS NOTHING
```