### PR TITLE
Odh v2.33 release

### DIFF
--- a/.tekton/odh-modelmesh-serving-controller-push.yaml
+++ b/.tekton/odh-modelmesh-serving-controller-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: odh-tag
-    value: odh-v2.33
+    value: odh-v2.34
   - name: output-image-base
     value: quay.io/opendatahub/modelmesh-controller
   - name: dockerfile


### PR DESCRIPTION
Update Tekton output-image tags to version odh-v2.34
[RHOAIENG-30987]