### PR TITLE
Add reference to etcd and ose-cli rhel9 manifest list image

### DIFF
--- a/config/dependencies/fvt.yaml
+++ b/config/dependencies/fvt.yaml
@@ -53,7 +53,7 @@ spec:
             - /tmp/etcd.data
           # image: quay.io/coreos/etcd:v3.5.4
           # Tag -> registry.access.redhat.com/rhel7/etcd:3.2.32-34
-          image: registry.redhat.io/openshift4/ose-etcd@sha256:d3275cd886d13865937d225d8138db7f6b7bf59ac1a94d9fbe61e35286bee6ff
+          image: $(ose-etcd)
           name: etcd
           ports:
             - containerPort: 2379

--- a/config/dependencies/fvt.yaml
+++ b/config/dependencies/fvt.yaml
@@ -53,7 +53,7 @@ spec:
             - /tmp/etcd.data
           # image: quay.io/coreos/etcd:v3.5.4
           # Tag -> registry.access.redhat.com/rhel7/etcd:3.2.32-34
-          image: $(etcd)
+          image: $(ose-etcd)
           name: etcd
           ports:
             - containerPort: 2379

--- a/config/dependencies/fvt.yaml
+++ b/config/dependencies/fvt.yaml
@@ -53,7 +53,7 @@ spec:
             - /tmp/etcd.data
           # image: quay.io/coreos/etcd:v3.5.4
           # Tag -> registry.access.redhat.com/rhel7/etcd:3.2.32-34
-          image: $(ose-etcd)
+          image: $(etcd)
           name: etcd
           ports:
             - containerPort: 2379

--- a/config/internal/base/deployment.yaml.tmpl
+++ b/config/internal/base/deployment.yaml.tmpl
@@ -136,7 +136,7 @@ spec:
             - '--openshift-delegate-urls={"/": {"namespace": "{{.AuthNamespace}}", "resource": "services", "verb": "get"}}'
             - '--openshift-sar={"namespace": "{{.AuthNamespace}}", "resource": "services", "verb": "get"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-          image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
+          image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:d3056b35d9a205b9f2c48d924f199c5ac23904eb18d526e4bff229e7c7181415
           ports:
             - containerPort: 8443
               name: https

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -56,8 +56,8 @@ vars:
     kind: ConfigMap
     name: mesh-parameters
 - fieldref:
-    fieldPath: data.etcd
-  name: etcd
+    fieldPath: data.ose-etcd
+  name: ose-etcd
   objref:
     apiVersion: v1
     kind: ConfigMap

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -62,6 +62,13 @@ vars:
     apiVersion: v1
     kind: ConfigMap
     name: mesh-parameters
+- fieldref:
+    fieldPath: data.ose-cli
+  name: ose-cli
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: mesh-parameters
 
 
 

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -55,6 +55,13 @@ vars:
     apiVersion: v1
     kind: ConfigMap
     name: mesh-parameters
+- fieldref:
+    fieldPath: data.ose-etcd
+  name: ose-etcd
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: mesh-parameters
 
 
 

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -56,8 +56,8 @@ vars:
     kind: ConfigMap
     name: mesh-parameters
 - fieldref:
-    fieldPath: data.ose-etcd
-  name: ose-etcd
+    fieldPath: data.etcd
+  name: etcd
   objref:
     apiVersion: v1
     kind: ConfigMap

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -2,3 +2,4 @@ odh-mm-rest-proxy=quay.io/opendatahub/rest-proxy:fast
 odh-modelmesh-runtime-adapter=quay.io/opendatahub/modelmesh-runtime-adapter:fast
 odh-modelmesh=quay.io/opendatahub/modelmesh:fast
 odh-modelmesh-controller=quay.io/opendatahub/modelmesh-controller:fast
+ose-etcd=registry.redhat.io/openshift4/ose-etcd-rhel9@sha256:ea7545b79599f3868d442fdffdfe9b12a02a4b56ac155f02c0fac4720d475796

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -2,5 +2,5 @@ odh-mm-rest-proxy=quay.io/opendatahub/rest-proxy:fast
 odh-modelmesh-runtime-adapter=quay.io/opendatahub/modelmesh-runtime-adapter:fast
 odh-modelmesh=quay.io/opendatahub/modelmesh:fast
 odh-modelmesh-controller=quay.io/opendatahub/modelmesh-controller:fast
-etcd=registry.redhat.io/openshift4/ose-etcd-rhel9@sha256:ea7545b79599f3868d442fdffdfe9b12a02a4b56ac155f02c0fac4720d475796
-ose-cli=registry.redhat.io/openshift4/ose-cli-rhel9@sha256:a11ea4a722fadc2cdf532675dd409d384342bea15559aec4b10c2b12ab6d3041
+ose-etcd=registry.redhat.io/openshift4/ose-etcd-rhel9:v4.19
+ose-cli=registry.redhat.io/openshift4/ose-cli-rhel9:v4.19

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -2,5 +2,5 @@ odh-mm-rest-proxy=quay.io/opendatahub/rest-proxy:fast
 odh-modelmesh-runtime-adapter=quay.io/opendatahub/modelmesh-runtime-adapter:fast
 odh-modelmesh=quay.io/opendatahub/modelmesh:fast
 odh-modelmesh-controller=quay.io/opendatahub/modelmesh-controller:fast
-ose-etcd=registry.redhat.io/openshift4/ose-etcd-rhel9@sha256:ea7545b79599f3868d442fdffdfe9b12a02a4b56ac155f02c0fac4720d475796
+etcd=registry.redhat.io/openshift4/ose-etcd-rhel9@sha256:ea7545b79599f3868d442fdffdfe9b12a02a4b56ac155f02c0fac4720d475796
 ose-cli=registry.redhat.io/openshift4/ose-cli-rhel9@sha256:a11ea4a722fadc2cdf532675dd409d384342bea15559aec4b10c2b12ab6d3041

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -3,3 +3,4 @@ odh-modelmesh-runtime-adapter=quay.io/opendatahub/modelmesh-runtime-adapter:fast
 odh-modelmesh=quay.io/opendatahub/modelmesh:fast
 odh-modelmesh-controller=quay.io/opendatahub/modelmesh-controller:fast
 ose-etcd=registry.redhat.io/openshift4/ose-etcd-rhel9@sha256:ea7545b79599f3868d442fdffdfe9b12a02a4b56ac155f02c0fac4720d475796
+ose-cli=registry.redhat.io/openshift4/ose-cli-rhel9@sha256:a11ea4a722fadc2cdf532675dd409d384342bea15559aec4b10c2b12ab6d3041

--- a/config/overlays/odh/params.yaml
+++ b/config/overlays/odh/params.yaml
@@ -7,5 +7,7 @@ varReference:
     kind: RoleBinding
   - path: spec/template/spec/containers[]/image
     kind: Deployment
+  - path: spec/template/spec/initContainers[]/image
+    kind: Deployment
   - path: data
     kind: ConfigMap

--- a/config/overlays/odh/quickstart.yaml
+++ b/config/overlays/odh/quickstart.yaml
@@ -49,7 +49,7 @@ spec:
             defaultMode: 0554
       initContainers:
         - name: etcd-secret-creator
-          image: registry.redhat.io/openshift4/ose-cli@sha256:4cfb4219f46c8cc25a5e567fd4cb8babe9a3778b0b86a1e354a3403994ef3677
+          image: $(ose-cli)
           command: ["/bin/bash", "-c", "--"]
           args:
             - |

--- a/config/overlays/odh/quickstart.yaml
+++ b/config/overlays/odh/quickstart.yaml
@@ -92,7 +92,7 @@ spec:
             - http://0.0.0.0:2379
             - "--data-dir"
             - /tmp/etcd.data
-          image: $(etcd)
+          image: $(ose-etcd)
           name: etcd
           env:
             - name: ROOT_PASSWORD

--- a/config/overlays/odh/quickstart.yaml
+++ b/config/overlays/odh/quickstart.yaml
@@ -92,7 +92,7 @@ spec:
             - http://0.0.0.0:2379
             - "--data-dir"
             - /tmp/etcd.data
-          image: $(ose-etcd)
+          image: $(etcd)
           name: etcd
           env:
             - name: ROOT_PASSWORD

--- a/config/overlays/odh/quickstart.yaml
+++ b/config/overlays/odh/quickstart.yaml
@@ -69,10 +69,10 @@ spec:
                 exit 0
               elif [[ $etcdpasswordexists == "false" && $modelservingetcdexists != "false" ]]; then
                 echo "model-serving-etcd exists, creating etcdpasswords secret"
-                ETC_ROOT_PSW=$(oc get secrets/model-serving-etcd --template={{.data.etcd_connection}} | base64 -d | grep -o '"password": *"[^"]*"' | grep -o '"[^"]*"$' | grep -oP '"\K[^"\047]+(?=["\047])') 
+                ETC_ROOT_PSW=$(oc get secrets/model-serving-etcd --template={{.data.etcd_connection}} | base64 -d | grep -o '"password": *"[^"]*"' | grep -o '"[^"]*"$' | grep -oP '"\K[^"\047]+(?=["\047])')
                 oc create secret generic etcd-passwords --type=string --from-literal=root=$ETC_ROOT_PSW
                 exit 0
-              else 
+              else
                 echo "secrets etcdpasswords and model-serving-etcd exist, doing nothing"
                 exit 0
               fi
@@ -92,7 +92,7 @@ spec:
             - http://0.0.0.0:2379
             - "--data-dir"
             - /tmp/etcd.data
-          image: registry.redhat.io/openshift4/ose-etcd@sha256:d3275cd886d13865937d225d8138db7f6b7bf59ac1a94d9fbe61e35286bee6ff
+          image: $(ose-etcd)
           name: etcd
           env:
             - name: ROOT_PASSWORD

--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -104,7 +104,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
+        image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:d3056b35d9a205b9f2c48d924f199c5ac23904eb18d526e4bff229e7c7181415
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -417,7 +417,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
+        image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:d3056b35d9a205b9f2c48d924f199c5ac23904eb18d526e4bff229e7c7181415
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -702,7 +702,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
+        image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:d3056b35d9a205b9f2c48d924f199c5ac23904eb18d526e4bff229e7c7181415
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1059,7 +1059,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
+        image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:d3056b35d9a205b9f2c48d924f199c5ac23904eb18d526e4bff229e7c7181415
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1365,7 +1365,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
+        image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:d3056b35d9a205b9f2c48d924f199c5ac23904eb18d526e4bff229e7c7181415
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1663,7 +1663,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
+        image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:d3056b35d9a205b9f2c48d924f199c5ac23904eb18d526e4bff229e7c7181415
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1966,7 +1966,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
+        image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:d3056b35d9a205b9f2c48d924f199c5ac23904eb18d526e4bff229e7c7181415
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -2263,7 +2263,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
+        image: registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:d3056b35d9a205b9f2c48d924f199c5ac23904eb18d526e4bff229e7c7181415
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/opendatahub/scripts/README.md
+++ b/opendatahub/scripts/README.md
@@ -19,7 +19,7 @@ manifests are the part that deploys the components required for fvt (functional 
 
 ## Scripts
 
-The scripts in this folder help you run fvt tests or compare odh manifests. However, it is not recommended to use these scripts directly without familiarizing yourself with them. [This doc has make examples](../docs/makefile_-cheatsheet.md) of using these scripts in a makefile here.
+The scripts in this folder help you run fvt tests or compare odh manifests. However, it is not recommended to use these scripts directly without familiarizing yourself with them. [This doc has make examples](../docs/makefile-cheatsheet.md) of using these scripts in a makefile here.
 
 - [env.sh](./env.sh)
 

--- a/opendatahub/scripts/manifests/fvt/fvt.yaml
+++ b/opendatahub/scripts/manifests/fvt/fvt.yaml
@@ -53,7 +53,7 @@ spec:
             - /tmp/etcd.data
           # image: quay.io/coreos/etcd:v3.5.4
           # Tag -> registry.access.redhat.com/rhel7/etcd:3.2.32-34
-          image: registry.redhat.io/openshift4/ose-etcd@sha256:d3275cd886d13865937d225d8138db7f6b7bf59ac1a94d9fbe61e35286bee6ff
+          image: $(ose-etcd)
           name: etcd
           ports:
             - containerPort: 2379

--- a/opendatahub/scripts/manifests/fvt/fvt.yaml
+++ b/opendatahub/scripts/manifests/fvt/fvt.yaml
@@ -53,7 +53,7 @@ spec:
             - /tmp/etcd.data
           # image: quay.io/coreos/etcd:v3.5.4
           # Tag -> registry.access.redhat.com/rhel7/etcd:3.2.32-34
-          image: $(etcd)
+          image: registry.redhat.io/openshift4/ose-etcd-rhel9@sha256:ea7545b79599f3868d442fdffdfe9b12a02a4b56ac155f02c0fac4720d475796
           name: etcd
           ports:
             - containerPort: 2379

--- a/opendatahub/scripts/manifests/fvt/fvt.yaml
+++ b/opendatahub/scripts/manifests/fvt/fvt.yaml
@@ -53,7 +53,7 @@ spec:
             - /tmp/etcd.data
           # image: quay.io/coreos/etcd:v3.5.4
           # Tag -> registry.access.redhat.com/rhel7/etcd:3.2.32-34
-          image: $(ose-etcd)
+          image: $(etcd)
           name: etcd
           ports:
             - containerPort: 2379

--- a/opendatahub/scripts/manifests/params.env
+++ b/opendatahub/scripts/manifests/params.env
@@ -5,4 +5,3 @@ odh-modelmesh=quay.io/opendatahub/modelmesh:fast
 odh-openvino=quay.io/opendatahub/openvino_model_server:2022.3-release
 odh-modelmesh-controller=quay.io/opendatahub/modelmesh-controller:fast
 odh-model-controller=quay.io/opendatahub/odh-model-controller:fast
-etcd=registry.redhat.io/openshift4/ose-etcd-rhel9@sha256:ea7545b79599f3868d442fdffdfe9b12a02a4b56ac155f02c0fac4720d475796

--- a/opendatahub/scripts/manifests/params.env
+++ b/opendatahub/scripts/manifests/params.env
@@ -5,3 +5,4 @@ odh-modelmesh=quay.io/opendatahub/modelmesh:fast
 odh-openvino=quay.io/opendatahub/openvino_model_server:2022.3-release
 odh-modelmesh-controller=quay.io/opendatahub/modelmesh-controller:fast
 odh-model-controller=quay.io/opendatahub/odh-model-controller:fast
+ose-etcd=registry.redhat.io/openshift4/ose-etcd-rhel9@sha256:ea7545b79599f3868d442fdffdfe9b12a02a4b56ac155f02c0fac4720d475796

--- a/opendatahub/scripts/manifests/params.env
+++ b/opendatahub/scripts/manifests/params.env
@@ -5,4 +5,4 @@ odh-modelmesh=quay.io/opendatahub/modelmesh:fast
 odh-openvino=quay.io/opendatahub/openvino_model_server:2022.3-release
 odh-modelmesh-controller=quay.io/opendatahub/modelmesh-controller:fast
 odh-model-controller=quay.io/opendatahub/odh-model-controller:fast
-ose-etcd=registry.redhat.io/openshift4/ose-etcd-rhel9@sha256:ea7545b79599f3868d442fdffdfe9b12a02a4b56ac155f02c0fac4720d475796
+etcd=registry.redhat.io/openshift4/ose-etcd-rhel9@sha256:ea7545b79599f3868d442fdffdfe9b12a02a4b56ac155f02c0fac4720d475796


### PR DESCRIPTION
#### Motivation

Update etcd and ose-cli images to follow guidelines

#### Modifications

Updated ectd and ose-cli images. 

#### Result

Test the release with [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator), and it release the correct images.

#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Etcd and CLI images made configurable via deployment parameters and templated placeholders; initContainer image reference path adjusted for deployment resolution.

- Chores
  - Updated default container images to RHEL9-based variants across configs and test manifests.
  - Minor formatting cleanups with no behavioral impact.

- Documentation
  - Fixed broken cheatsheet link in the scripts README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->