### PR TITLE
[RHOAIENG-31975] - Onboard metrics to the centralized metrics platform

### DIFF
--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -49,8 +49,9 @@ import (
 )
 
 const (
-	commonLabelValue   = "modelmesh-controller"
-	serviceMonitorName = "modelmesh-metrics-monitor"
+	commonLabelValue        = "modelmesh-controller"
+	serviceMonitorName      = "modelmesh-metrics-monitor"
+	rhoaiObservabilityLabel = "monitoring.opendatahub.io/scrape"
 )
 
 // This is a map in preparation for multi-namespace support
@@ -347,6 +348,9 @@ func (r *ServiceReconciler) reconcileServiceMonitor(ctx context.Context, metrics
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceMonitorName,
 			Namespace: owner.GetNamespace(),
+			Labels: map[string]string{
+				rhoaiObservabilityLabel: "true",
+			},
 		},
 	}
 


### PR DESCRIPTION
chore:  Add the `monitoring.opendatahub.io/scrape: "true"` anntation to
        Pod and Service monitors so the metrics can be collected by the
        Centralized RHOAI Observability platform.

#### Motivation

#### Modifications

#### Result


#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enables automatic metrics scraping by labeling ServiceMonitor resources, improving default observability.
  * Monitoring systems now detect and collect metrics without manual configuration, enhancing dashboards and alerts availability.
  * Provides more reliable visibility into service health and performance across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->