### PR TITLE
Allow running the controller on arm64

### DIFF
--- a/config/overlays/odh/manager/kustomization.yaml
+++ b/config/overlays/odh/manager/kustomization.yaml
@@ -21,3 +21,4 @@ patches:
                   operator: In
                   values:
                     - amd64
+                    - arm64


### PR DESCRIPTION
#### Motivation
For RHOAI 2.25, the controller is built for arm64, so it needs to be allowed to run there also.

#### Modifications

#### Result


#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
