### PR TITLE
Add Konflux ODH tag bump automation to our existing release workflow.

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,8 +4,18 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: 'Tag name for the new release'
+        description: 'New release tag (e.g., odh-v2.35)'
         required: true
+        type: string
+      next_odh_tag:
+        description: 'Next development tag (e.g., odh-v2.36)'
+        required: true
+        type: string
+    #
+    # Note: This workflow assumes the release tag and image tags are in sync.
+    #       'tag_name' is used to create the release and as the value to find in files.
+    #       'next_odh_tag' provides the new value to set.
+    #
 
 permissions:
   contents: write
@@ -101,3 +111,42 @@ jobs:
           files: bin/*
           generate_release_notes: true
           name: ${{ github.event.inputs.tag_name }}
+
+  bump-odh-tag:
+    name: Bump ODH Tag for Next Release
+    runs-on: ubuntu-latest
+    needs: changelog
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Update odh-modelmesh-serving-controller-push.yaml with next ODH tag
+        run: |
+          CURRENT_TAG="${{ github.event.inputs.tag_name }}"
+          NEXT_TAG="${{ github.event.inputs.next_odh_tag }}"
+          
+          echo "Updating ODH tag from $CURRENT_TAG to $NEXT_TAG..."
+          
+          # Using sed to replace the current ODH tag with the next one,
+          # anchored to the 'value: ' line to prevent over-matching.
+          sed -i "s|value: ${CURRENT_TAG}|value: ${NEXT_TAG}|g" .tekton/odh-modelmesh-serving-controller-push.yaml
+
+          echo "Update complete."
+          
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git add .tekton/odh-modelmesh-serving-controller-push.yaml
+          
+          # Check for changes before committing
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "No changes to commit. Exiting."
+          else
+            git commit -m "chore(konflux): Bump ODH release tag to ${{ github.event.inputs.next_odh_tag }}"
+            git push
+          fi


### PR DESCRIPTION
#### Motivation
This PR automates the process of updating the ODH release tag in the `modelmesh-serving` repository's `Tekton` build file. This is a crucial step for preparing the codebase for the next development sprint immediately after a new release is cut.

#### Modifications
* Added a new job named `bump-odh-tag` to the `create-release.yaml` workflow.
* Updated the `workflow_dispatch` trigger to include a `next_odh_tag` input.
* The new job uses a `sed` command anchored to the `value:` prefix to precisely update the tag from `odh-v2.35` to `odh-v2.36` in the `.tekton/odh-modelmesh-serving-controller-push.yaml` file.

#### Result
The automation successfully updated the image tag in the specified `Tekton` file. A test run using `odh-v2.35` as the current tag and `odh-v2.36` as the next tag successfully modified the `value` field from `odh-v2.35` to `odh-v2.36` and created a new release as intended. The changes were then reverted and squashed for a clean PR.


#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
