### PR TITLE
Odh v2.35 release

### DIFF
--- a/.tekton/odh-modelmesh-serving-controller-push.yaml
+++ b/.tekton/odh-modelmesh-serving-controller-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: odh-tag
-    value: odh-v2.35
+    value: odh-v2.36
   - name: output-image-base
     value: quay.io/opendatahub/modelmesh-controller
   - name: dockerfile


### PR DESCRIPTION
Update Tekton output-image tags to version odh-v2.36
[RHOAIENG-34063]