### PR TITLE
fix: CVE-61729 upgrading go to 1.25

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.60.3
+    rev: v2.10.1
     hooks:
       - id: golangci-lint
         entry: golangci-lint run

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kserve/modelmesh-serving
 
-go 1.23.6
+go 1.25.5
 
 require (
 	github.com/dereklstinson/cifar v0.0.0-20200421171932-5722a3b6a0c7


### PR DESCRIPTION
Upgrades Go from `1.23.6` to `1.25.5+` to address CVE-2025-61729

  Changes:
  - Update go.mod to require Go 1.25.5
  - Upgrade golangci-lint from v1.60.3 to v2.10.1 for Go 1.25 compatibility

  The fix has been verified with Go 1.25.7 (Red Hat build) which exceeds
  the minimum required version of 1.25.5.

[RHOAIENG-44773](https://issues.redhat.com/browse/RHOAIENG-44773)
