### PR TITLE
Fix CI - update setup-envtest

### DIFF
--- a/Dockerfile.develop.ci
+++ b/Dockerfile.develop.ci
@@ -116,10 +116,10 @@ RUN true \
     && ginkgo version \
     && true
 
-# Use setup-envtest for kubebuilder to use K8s version 1.23+ for autoscaling/v2 (HPA)
+# Use setup-envtest for kubebuilder to use K8s version 1.28+ for autoscaling/v2 (HPA)
 RUN true \
-    && go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240320141353-395cfc7486e6 \
-    && setup-envtest use 1.26 \
+    && go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.19 \
+    && setup-envtest use 1.28 \
     && true
 
 # For GitHub Action 'lint', work around error "detected dubious ownership in repository at '/workspace'"


### PR DESCRIPTION
setup-envtest version: v0.0.0-20240320141353-395cfc7486e6 → release-0.19 (uses the new HTTP index instead of the deprecated GCS bucket)

#### Motivation

#### Modifications

#### Result


#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
