### PR TITLE
Add jlost to OWNERS as approver and reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,24 +2,22 @@ approvers:
   - andresllh
   - brettmthompson
   - danielezonca
-  - hdefazio
   - israel-hdez
+  - jlost
   - Jooho
   - mholder6
   - mwaykole
-  - rnetser
   - spolti
   - terrytangyuan
   - VedantMahabaleshwarkar
 reviewers:
   - andresllh
   - brettmthompson
-  - hdefazio
   - israel-hdez
+  - jlost
   - Jooho
   - mholder6
   - mwaykole
-  - rnetser
   - spolti
   - terrytangyuan
   - VedantMahabaleshwarkar


### PR DESCRIPTION
## Summary
- Adds `jlost` (James Ostrander) to the OWNERS file as both an approver and reviewer.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration: removed two approvers/reviewers and added one new approver/reviewer in the ownership settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->