### PR TITLE
feat: set NextProtos on gRPC and etcd TLS client configs

### DIFF
--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -227,7 +227,7 @@ func (r *ServiceReconciler) tlsConfigFromSecret(ctx context.Context, secretName 
 	if ok := certPool.AppendCertsFromPEM(cert); !ok {
 		return nil, errors.New("failed to append ca certs")
 	}
-	return &tls.Config{Certificates: []tls.Certificate{certificate}, RootCAs: certPool}, nil
+	return &tls.Config{Certificates: []tls.Certificate{certificate}, RootCAs: certPool, MinVersion: tls.VersionTLS12, NextProtos: []string{"h2"}}, nil
 }
 
 func (r *ServiceReconciler) reconcileService(ctx context.Context, mms *mmesh.MMService,

--- a/pkg/mmesh/etcdrangewatcher.go
+++ b/pkg/mmesh/etcdrangewatcher.go
@@ -301,6 +301,8 @@ func getEtcdClientConfig(etcdConfig EtcdConfig, secretData map[string][]byte, lo
 		if tlsConfig.RootCAs == nil {
 			tlsConfig.RootCAs, _ = x509.SystemCertPool()
 		}
+		tlsConfig.MinVersion = tls.VersionTLS12
+		tlsConfig.NextProtos = []string{"h2"}
 		etcdClientConfig.TLS = &tlsConfig
 	}
 

--- a/pkg/mmesh/modelmesh_service.go
+++ b/pkg/mmesh/modelmesh_service.go
@@ -264,6 +264,7 @@ func newMmClient(ctx context.Context, mmeshEndpoint string, tlsConfig *tls.Confi
 	if tlsConfig == nil {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
+		tlsConfig.NextProtos = []string{"h2"}
 		tc := credentials.NewTLS(tlsConfig)
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(tc), grpc.WithAuthority(serviceName))
 	}


### PR DESCRIPTION
## Summary
- Add ALPN `h2` negotiation to all gRPC and etcd TLS configurations
- Uses `h2` only (no `http/1.1` fallback) since all endpoints are gRPC which requires HTTP/2
- Ensures proper protocol negotiation on OpenShift clusters where ALPN is required

## Files changed
- `controllers/service_controller.go` - TLS config returned by `tlsConfigFromSecret` (used for gRPC connections)
- `pkg/mmesh/modelmesh_service.go` - gRPC dial TLS credentials in `newMmClient`
- `pkg/mmesh/etcdrangewatcher.go` - etcd client TLS config in `getEtcdClientConfig`

## Test plan
- [x] `go build ./...` passes
- [ ] Verify modelmesh gRPC connections work over TLS on OpenShift
- [ ] Verify etcd client connections work over TLS on OpenShift

Ref: [RHOAIENG-61383](https://redhat.atlassian.net/browse/RHOAIENG-61383)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated TLS connection settings to explicitly advertise HTTP/2 via ALPN negotiation.
  * Applies to internal service TLS, etcd TLS client connections, and gRPC TLS transports for consistent HTTP/2 behavior when TLS is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->